### PR TITLE
drop requirement that only releases by gh bot get copied to production branch

### DIFF
--- a/.github/workflows/copy-release-tag-to-production-branch.yml
+++ b/.github/workflows/copy-release-tag-to-production-branch.yml
@@ -10,7 +10,6 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: github.event.release.author.login == 'github-actions[bot]'
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,4 +15,5 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
+          token: ${{ secrets.RELEASE_PLEASE_PAT }}
           release-type: node


### PR DESCRIPTION
- **ci: use PAT for release-please**
- **ci: drop the requirement that only auto-created tags get put on production branch**
