### PR TITLE
helpful vectors not on joysticks

### DIFF
--- a/src/game/mainLoop/playThroughIntegrationTests/helpfulVectorsIntegration.test.ts
+++ b/src/game/mainLoop/playThroughIntegrationTests/helpfulVectorsIntegration.test.ts
@@ -48,6 +48,39 @@ test("player slides at a normal to the input direction when partially overlappin
   expect(heelsState(gameState).position.y).toBeGreaterThan(startY);
 });
 
+test("player doesn't slide on joysticks since we want to keep pushing these", () => {
+  const gameState = setUpBasicGame({
+    firstRoomItems: {
+      heels: {
+        type: "player",
+        position: { x: 4, y: 4, z: 0 },
+        config: {
+          which: "heels",
+        },
+      },
+      soothingToRunInto: {
+        type: "joystick",
+        position: { x: 2, y: 3.5, z: 0 },
+        config: {
+          controls: [],
+        },
+      },
+    },
+  });
+
+  const startY = heelsState(gameState).position.y;
+
+  playGameThrough(gameState, {
+    setupInitialInput(mockInputStateTracker) {
+      mockInputStateTracker.mockDirectionPressed = "right";
+    },
+    until: 5_000,
+  });
+
+  // did not slide in y - still at same ordinal:
+  expect(heelsState(gameState).position.y).toEqual(startY);
+});
+
 test("player slides at a normal to the input direction after initially pushing a portable block without sliding", () => {
   const gameState = setUpBasicGame({
     firstRoomItems: {


### PR DESCRIPTION
- **feat: use F8, F9, F10 to change display settings in default keybindings**
- **fix: do not apply sliding to help walk around joystick items, since we want to keep pushing these**
