### PR TITLE
fix: bug where short hits on movement keys would sometimes not cause any movement

### DIFF
--- a/src/game/mainLoop/playThroughIntegrationTests/walking.test.ts
+++ b/src/game/mainLoop/playThroughIntegrationTests/walking.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+vi.mock("../../sprites/samplePalette", () => ({
+  spritesheetPalette: vi.fn().mockReturnValue({}),
+}));
+
+import { setUpBasicGame } from "../../../_testUtils/basicRoom";
+import { currentPlayableState } from "../../../_testUtils/characterState";
+import { resetStore } from "../../../_testUtils/initStoreForTests";
+import { playGameThrough } from "../../../_testUtils/playGameThrough";
+import { individualCharacterNames } from "../../../model/modelTypes";
+import { unitVectors } from "../../../utils/vectors/unitVectors";
+
+beforeEach(() => {
+  resetStore();
+});
+
+describe.each(individualCharacterNames)("%s", (which) => {
+  test("moves exactly 1px when directional input is applied for a single frame in direction already facing", () => {
+    const gameState = setUpBasicGame({
+      firstRoomItems: {
+        [which]: {
+          type: "player",
+          position: { x: 4, y: 4, z: 0 },
+          config: {
+            which,
+          },
+        },
+      },
+    });
+
+    const initialPosition = { ...currentPlayableState(gameState).position };
+    const initialFacing = { ...currentPlayableState(gameState).facing };
+
+    let frameCount = 0;
+
+    // check we will be facing "towards" initially, so when we walk we are going in
+    // the direction already facing:
+    expect(initialFacing).toEqual(unitVectors.towards);
+
+    playGameThrough(gameState, {
+      setupInitialInput(mockInputStateTracker) {
+        mockInputStateTracker.mockDirectionPressed = "towards";
+      },
+      frameCallbacks(gameState, mockInputStateTracker) {
+        frameCount++;
+        if (frameCount === 2) {
+          // after first frame, stop pressing direction
+          mockInputStateTracker.mockDirectionPressed = undefined;
+        }
+      },
+      until: 500,
+    });
+
+    const finalPosition = currentPlayableState(gameState).position;
+
+    // "towards" direction decreases y
+    expect(finalPosition.x).toBe(initialPosition.x);
+    expect(finalPosition.y - initialPosition.y).toBe(-1);
+    expect(finalPosition.z).toBe(initialPosition.z);
+  });
+
+  test("does not move when directional input is perpendicular to facing direction", () => {
+    const gameState = setUpBasicGame({
+      firstRoomItems: {
+        [which]: {
+          type: "player",
+          position: { x: 4, y: 4, z: 0 },
+          config: {
+            which,
+          },
+        },
+      },
+    });
+
+    const initialPosition = { ...currentPlayableState(gameState).position };
+    const initialFacing = { ...currentPlayableState(gameState).facing };
+
+    let frameCount = 0;
+
+    // check we will be facing "towards" initially
+    expect(initialFacing).toEqual(unitVectors.towards);
+
+    playGameThrough(gameState, {
+      setupInitialInput(mockInputStateTracker) {
+        // "right" is perpendicular to "towards"
+        mockInputStateTracker.mockDirectionPressed = "right";
+      },
+      frameCallbacks(gameState, mockInputStateTracker) {
+        frameCount++;
+        if (frameCount === 2) {
+          mockInputStateTracker.mockDirectionPressed = undefined;
+        }
+      },
+      until: 500,
+    });
+
+    // should not have moved at all - only rotated
+    expect(currentPlayableState(gameState).position).toMatchObject(
+      initialPosition,
+    );
+    expect(currentPlayableState(gameState).facing).toMatchObject(
+      unitVectors.right,
+    );
+  });
+});

--- a/src/game/mainLoop/tickItem.ts
+++ b/src/game/mainLoop/tickItem.ts
@@ -241,9 +241,12 @@ export const tickItem = <
   // time, before the previous ones have changed the game state. This is good for
   // jumping and carrying at the same time, for example. Otherwise, these would
   // one stop the other from working.
-  const mechanicsResults = [
-    ...itemMechanicResultGen(item, room, gameState, deltaMS),
-  ];
+  const mechanicsResults = itemMechanicResultGen(
+    item,
+    room,
+    gameState,
+    deltaMS,
+  ).toArray();
 
   // this is done after the mechanicsResults are generated, so that the player
   // can do one more jump on a dissapearing block before the touch on that block
@@ -276,11 +279,19 @@ export const tickItem = <
     addParticlesAroundCrown(room, item, deltaMS);
   }
 
-  constrainToMaximumSpeedInPlace(
-    item,
-    tickItemPosDeltaAccumulationBuffer,
-    deltaMS,
-  );
+  // position deltas are instant - not subject to maximum speed constraints
+  // currently. Otherwise, the minimum 1px walking movement on short input
+  // bursts gets cancelled
+  const mrIncludesInstantMovement =
+    mechanicsResults.find((mr) => mr.movementType === "position") !== undefined;
+
+  if (!mrIncludesInstantMovement) {
+    constrainToMaximumSpeedInPlace(
+      item,
+      tickItemPosDeltaAccumulationBuffer,
+      deltaMS,
+    );
+  }
 
   moveItem({
     subjectItem: item as UnionOfAllItemInPlayTypes<RoomId>,

--- a/src/game/physics/mechanics/walking.ts
+++ b/src/game/physics/mechanics/walking.ts
@@ -314,7 +314,11 @@ const walkingImpl = <RoomId extends string, RoomItemId extends string>(
     return {
       movementType: "position",
       posDelta: scaleXyz(facing, targetDistance - walkDistance),
-      stateDelta: { action: isFalling ? "falling" : "idle", walkDistance: 0 },
+      stateDelta: {
+        action: isFalling ? "falling" : "idle",
+        walkDistance: 0,
+        facing,
+      },
     };
   }
 


### PR DESCRIPTION
This was because the movement was being cancelled out for being too fast, owing to items having a
max possible composite speed from all mechanics
