### PR TITLE
ci: pre-commit hook formats e2e, gfx, and scripts directories

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,5 @@
 echo running pre-commit...
 echo git-format-staged
-git-format-staged --formatter 'prettier --stdin-filepath "{}"' 'src/*.ts' 'src/*.tsx' 'src/*.json' 'src/*.html'
+git-format-staged --formatter 'prettier --stdin-filepath "{}"' 'src/*.ts' 'src/*.tsx' 'src/*.json' 'src/*.html' 'e2e/*.ts' 'gfx/*.ts' 'scripts/*.ts'
 echo ...pre-commit done
 


### PR DESCRIPTION
## Summary
- Extends the pre-commit prettier hook to also format files in `e2e/`, `gfx/`, and `scripts/` directories, matching what `pnpm fix` already covers