### PR TITLE
editor insert room

### DIFF
--- a/.claude/skills/editor-qa/SKILL.md
+++ b/.claude/skills/editor-qa/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: editor-qa
+description: QA the level editor via the chrome-devtools MCP — start the dev server, open it in a browser, dispatch actions, and verify Redux state. Use when testing editor features interactively.
+---
+
+## Starting the editor
+
+```sh
+eval "$(fnm env)" && fnm use && pnpm dev:editor
+```
+
+Run this in the background. The editor vite config is separate from the game's. Check the port with:
+
+```sh
+lsof -p <pid> -i -a 2>/dev/null | grep LISTEN
+```
+
+The URL will be `http://localhost:<port>/editor/`.
+
+## Opening in Chrome
+
+Use `mcp__chrome-devtools__new_page` with the editor URL. The editor loads directly — no menu navigation needed.
+
+## Redux store access
+
+The store is exposed at `window._e2e_store`. All editor state is under `state.levelEditor`.
+
+```js
+const state = window._e2e_store.getState();
+const le = state.levelEditor;
+
+le.currentlyEditingRoomId        // which room is active
+le.campaignInProgress.rooms      // all rooms keyed by ID
+le.selectedJsonItemIds           // currently selected items
+le.tool                          // current editing tool
+```
+
+## Dispatching editor actions
+
+Dispatch actions directly via the store rather than clicking UI buttons — DOM uids become stale after re-renders.
+
+```js
+// Insert a room to the left
+store.dispatch({ type: "levelEditor/insertRoom", payload: { direction: "left" } });
+
+// Add a new room (default 8x8)
+store.dispatch({ type: "levelEditor/addRoom", payload: { roomSize: { x: 8, y: 8 } } });
+
+// Switch rooms
+store.dispatch({ type: "levelEditor/changeToRoom", payload: "room_1" });
+
+// Delete the current room
+store.dispatch({ type: "levelEditor/removeRoom" });
+```
+
+All level editor actions are namespaced `levelEditor/`.
+
+## Inspecting doors and room connections
+
+```js
+const rooms = store.getState().levelEditor.campaignInProgress.rooms;
+for (const [roomId, room] of Object.entries(rooms)) {
+  for (const [itemId, item] of Object.entries(room.items)) {
+    if (item.type === "door") {
+      console.log(roomId, itemId, item.config.direction, "→", item.config.toRoom, "toDoor:", item.config.toDoor);
+    }
+  }
+}
+```
+
+Door config properties:
+- `direction`: "left" | "right" | "away" | "towards"
+- `toRoom`: destination room ID (or "$$final" for game exit)
+- `toDoor`: ID of the corresponding door in the destination room (optional)
+
+## Resetting to a blank campaign
+
+**Option 1 — dispatch newCampaign:**
+
+```js
+store.dispatch({ type: "levelEditor/newCampaign" });
+```
+
+Creates a fresh single-room campaign. This is the cleanest reset.
+
+**Option 2 — click the NEW button in the UI** (uid may change between renders).
+
+## Persistence
+
+Editor state is persisted to localStorage under `persist:hohol/levelEditor`. This means:
+- **Reloading the page keeps the current campaign** — it rehydrates from localStorage.
+- `newCampaign` dispatch resets the in-memory state, and persistence follows.
+- If the state gets corrupted (e.g. bad `roomJsonEdited` dispatch), click "Clear all data" in the crash dialog, or run:
+
+```js
+localStorage.removeItem("persist:hohol/levelEditor");
+```
+
+Then reload.
+
+## Verifying results
+
+After dispatching an action, read the store state to verify. Don't rely on screenshots alone for structural verification — the Redux state is the source of truth.
+
+```js
+const le = store.getState().levelEditor;
+const roomIds = Object.keys(le.campaignInProgress.rooms);
+// Check room count, door connections, toDoor cross-links, etc.
+```
+
+For visual verification (button placement, rendering), take a screenshot after the state check.
+
+## Gotchas
+
+- **Stale uids:** After any state change that re-renders the toolbar (adding rooms, switching rooms), snapshot uids are invalidated. Prefer JS dispatch over clicking buttons.
+- **roomJsonEdited pitfall:** The `roomJsonEdited` action expects a JSON string of the *entire room*. Passing malformed data corrupts the persisted state. Prefer dispatching specific actions instead.
+- **Door width:** Doors occupy 2 block units. When centering on an N-unit wall, the position should be `(N - 2) / 2`, not `N / 2`.

--- a/.claude/skills/fetch-campaign/SKILL.md
+++ b/.claude/skills/fetch-campaign/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: fetch-campaign
+description: Fetch a campaign from the Supabase DB and save as local JSON. Use when the user asks to load, download, or fetch a campaign from the database.
+---
+
+## Usage
+
+```sh
+eval "$(fnm env)" && fnm use && npx tsx scripts/fetchCampaign.ts <campaignName> [userId]
+```
+
+The default user ID is `2924c962-99f1-4dd2-9b9c-fef832dc991b` (Jim's account). Pass a different user ID as the second argument if needed.
+
+Output is written to stdout. Redirect to a file if needed.
+
+## Examples
+
+```sh
+# fetch Jim's campaign to a file
+npx tsx scripts/fetchCampaign.ts sequel_23 > /tmp/sequel_23.json
+
+# fetch another user's campaign
+npx tsx scripts/fetchCampaign.ts my_campaign abc123-def456 > /tmp/my_campaign.json
+
+# pipe to jq to inspect a specific room
+npx tsx scripts/fetchCampaign.ts sequel_23 | jq '.rooms["head_homers_jump"].meta.subRooms'
+```
+
+## How it works
+
+The script calls the `get_latest_campaign` Supabase RPC, which returns a gzip+base64 encoded blob. It decodes with `js-base64` and `node:zlib` gunzip, then prints the parsed JSON to stdout.

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: ship
+description: Pre-flight checks, commit hygiene, PR creation, and CI monitoring for shipping a branch. Use when the user says "ship", "ship it", "merge this", "raise a PR", or wants to go through the commit-and-PR workflow.
+---
+
+Walk through each phase in order. Ask the user before taking any destructive action.
+
+## Phase 1: Pre-flight checks
+
+Offer to run checks. If the user declines, skip to Phase 2.
+
+1. **Type check + lint + unit tests:** `eval "$(fnm env)" && fnm use && pnpm check`
+2. **E2e tests (chromium-desktop only):** `eval "$(fnm env)" && fnm use && pnpm build:game && pnpm playwright test --project=chromium-desktop`
+
+Report results. If failures, offer to investigate before continuing.
+
+## Phase 1b: Editor QA (if the branch touches editor code)
+
+Check whether the branch includes changes under `src/editor/`. If so, offer to QA the editor interactively via the chrome-devtools MCP.
+
+1. **Start the editor dev server** (if not already running):
+   ```sh
+   eval "$(fnm env)" && fnm use && pnpm dev:editor
+   ```
+   Run in the background. Find the port with `lsof -p <pid> -i -a | grep LISTEN`.
+
+2. **Open in Chrome:**
+   ```
+   mcp__chrome-devtools__new_page({ url: "http://localhost:<port>/editor/" })
+   ```
+
+3. **Access the Redux store** at `window._e2e_store`:
+   ```js
+   const le = window._e2e_store.getState().levelEditor;
+   le.currentlyEditingRoomId;
+   le.campaignInProgress.rooms;
+   ```
+
+4. **Reset to a clean campaign** before testing:
+   ```js
+   window._e2e_store.dispatch({ type: "levelEditor/newCampaign" });
+   ```
+
+5. **Exercise the changed features** by dispatching actions directly (more reliable than clicking UI buttons, which suffer from stale uids after re-renders):
+   ```js
+   window._e2e_store.dispatch({ type: "levelEditor/<action>", payload: { ... } });
+   ```
+
+6. **Verify state** after each action by reading the store. Check room counts, door connections, item positions, toDoor cross-links, etc. Take screenshots for visual confirmation but treat the Redux state as the source of truth.
+
+7. **Persistence caveat:** editor state persists to localStorage. If the state gets corrupted, clear it:
+   ```js
+   localStorage.removeItem("persist:hohol/levelEditor");
+   ```
+   Then reload the page.
+
+Report QA results to the user before proceeding.
+
+## Phase 2: Commit hygiene
+
+Count commits ahead of main:
+
+```sh
+git rev-list --count origin/main..HEAD
+```
+
+Show them:
+
+```sh
+git log --oneline origin/main..HEAD
+```
+
+### If exactly 1 commit ahead
+
+Confirm the commit message follows release-please conventions (check `package.json` or `.release-please-manifest.json` for the schema). If it looks good, proceed to Phase 3.
+
+### If multiple commits ahead, all related
+
+Offer to squash into a single commit. If the user confirms:
+
+```sh
+git reset --soft origin/main
+git commit -m "<message>"
+```
+
+Draft the squashed commit message from the combined changes and ask the user to confirm it.
+
+### If multiple commits ahead, some unrelated
+
+Explain the situation clearly: "There are N commits ahead of main, but some appear unrelated to this branch's purpose." List them and ask the user which commit(s) belong on this branch.
+
+If the user confirms which to keep, offer to reset and cherry-pick:
+
+```sh
+git reset --hard origin/main
+git cherry-pick <commit-sha>
+```
+
+**This is destructive** — get explicit confirmation before running `git reset --hard`.
+
+If the unrelated commits need to be preserved elsewhere, suggest the user stash or branch them first.
+
+## Phase 3: Push and PR
+
+Push the branch and create a PR:
+
+```sh
+git push -u origin HEAD
+gh pr create -f
+```
+
+The `-f` flag uses the commit message as the PR title and body — this is the project convention.
+
+Report the PR URL.
+
+## Phase 4: CI monitoring
+
+Offer to monitor the PR's CI checks in the background. If the user accepts, spawn a background agent that:
+
+1. Polls `gh pr checks <pr-number> --watch` or periodically runs `gh pr checks <pr-number>` with sleeps between polls.
+2. Reports back when all checks pass, or when any check fails.
+3. On failure: fetches the failed check's log via `gh run view <run-id> --log-failed`, summarises the failure, and offers possible fixes.
+4. On success: notifies the user that CI is green and the PR is ready to merge.
+
+Use `ScheduleWakeup` or a background `Agent` for the monitoring — don't block the main conversation.
+
+### Monitoring implementation
+
+```
+Poll cadence: ~270s (stays within the prompt-cache TTL window).
+Fallback timeout: 1200s if no signal.
+```
+
+Each poll:
+```sh
+gh pr checks <pr-number>
+```
+
+Parse the output for "fail", "pending", "pass" states. If all pass → notify success. If any fail → fetch logs and report.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,7 @@ Prefer `roomJsonItemsIterable` when you only need items without ids. Use `iterat
 ## Style & Tooling:
  * do not make barrel files inside a package. Within a package, import directly from the file that declares the property you want. The single exception: each package's top-level `src/index.ts` serves as the package's public API and must re-export every symbol the package exposes externally, so the barrel doubles as an explicit list of the package's public surface. Cross-package imports always go through the barrel (eg `import { RoomJson } from "@blockstacking/hoh-common"`, never via deep paths).
  * inline calls to hooks so long as they don't cause conditional calling or otherwise break the rules of hooks
+ * extract a custom hook for any nameable piece of logic that groups multiple base hooks together (eg a `useMemo` + `useSelector` that computes a derived value). The hook name documents the intent.
  * instead of `<Fragment>`, write the shorthand `<>` instead where possible
  * do not use bare `PropsWithChildren` — its default type param is `unknown`, which silently widens props. If a component takes no props beyond `children`, write `PropsWithChildren<EmptyObject>` (importing `EmptyObject` from `type-fest`). Otherwise pass the actual props type as the generic.
  * extract a named props type for components rather than writing the shape inline at the destructure site. Name it `<ComponentName>Props` and export it. Eg `type FooProps = { ... }; export const Foo = ({ x }: FooProps) => ...` — not `export const Foo = ({ x }: { x: number }) => ...`.
@@ -159,6 +160,14 @@ Prefer `roomJsonItemsIterable` when you only need items without ids. Use `iterat
  * do not use very generic variable names such as `data`
  * Do not use `any` unless completely necessary. Cast to a type that better describes what we know about the data - it is very rare to have a variable that can genuinely have any value.
  * write typescript type assertions to narrow down types where useful and necessary
+ * for `key in obj` narrowing, extract a type predicate function rather than casting after the check:
+ ```ts
+ const isFoo = (key: string): key is FooKey => key in fooMap;
+ ```
+ * use `as const satisfies` for lookup objects to get both narrow literal types and compile-time key validation:
+ ```ts
+ const map = { ArrowLeft: "left", ArrowRight: "right" } as const satisfies { [K in Key]?: Direction };
+ ```
  * never write comments that say something like `/* this now does foo */` because this assumes the reader has familiarity with previous versions of the code, which are invisible to them unless they look in git history. All descriptions should be of the current version, as it is now, not in reference to previous versions.
 
 * use iterator helper methods, and don't turn iterators into arrays using `[...iter]` unless really necessary; for example, use the helper methods to call `.map` or `.filter` directly on the iter. Only write to an array if we need to pass to an api that requires one, or we need to refer to the collection more than once. In this case, use `.toArray()` to convert it.

--- a/scripts/fetchCampaign.ts
+++ b/scripts/fetchCampaign.ts
@@ -1,0 +1,33 @@
+import { createClient } from "@supabase/supabase-js";
+import { toUint8Array } from "js-base64";
+import { gunzipSync } from "node:zlib";
+
+const [, , campaignName] = process.argv;
+if (!campaignName) {
+  console.error("usage: tsx scripts/fetchCampaign.ts <campaignName> [userId]");
+  process.exit(1);
+}
+
+const defaultUserId = "2924c962-99f1-4dd2-9b9c-fef832dc991b";
+const [, , , userId = defaultUserId] = process.argv;
+
+const supabase = createClient(
+  "https://pkswdnpftrundnewgnya.supabase.co",
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InBrc3dkbnBmdHJ1bmRuZXdnbnlhIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTI2ODI2MzIsImV4cCI6MjA2ODI1ODYzMn0.r_Y1RLOGJ55C0De5SBTVXqO09SMDqgV38sQuE-oDxXE",
+);
+
+const res = await supabase.rpc("get_latest_campaign", {
+  p_campaign_name: campaignName,
+  p_user_id: userId,
+});
+
+if (res.error) {
+  console.error("error fetching campaign:", res.error);
+  process.exit(1);
+}
+
+const compressed = toUint8Array(res.data.data);
+const decompressed = gunzipSync(Buffer.from(compressed));
+const campaign = JSON.parse(decompressed.toString("utf-8"));
+
+console.log(JSON.stringify(campaign, null, 2));

--- a/src/editor/EditorMap/EditorMap.tsx
+++ b/src/editor/EditorMap/EditorMap.tsx
@@ -1,10 +1,118 @@
+import type { KeyboardEvent } from "react";
+
+import type { WrapClickableRoomDecoratorComponent } from "../../game/components/dialogs/menuDialog/dialogs/map/RoomDecoratorProps";
+import type { SortedObjectOfRoomGridPositionSpecs } from "../../game/components/dialogs/menuDialog/dialogs/map/sortRoomGridPositions";
+import type { EditorRoomId } from "../editorTypes";
+
+import { createClickableRoomDecorator } from "../../game/components/dialogs/menuDialog/dialogs/map/createClickableRoomDecorator";
+import { LazyMapRoomTooltipDecorator } from "../../game/components/dialogs/menuDialog/dialogs/map/LazyMapRoomTooltipDecorator";
 import { MapSvg } from "../../game/components/dialogs/menuDialog/dialogs/map/Map.svg";
 import { BitmapText } from "../../game/components/tailwindSprites/BitmapText";
+import { type Key } from "../../game/input/keys";
 import { store } from "../../store/store";
+import { valuesIter } from "../../utils/entries";
 import { useElementSize } from "../../utils/react/useElementSize";
-import { type EditorRoomId } from "../editorTypes";
-import { changeToRoom } from "../slice/levelEditorSlice";
+import { unitVectors } from "../../utils/vectors/unitVectors";
+import { addXyz, xyzEqual } from "../../utils/vectors/vectors";
+import {
+  changeToRoom,
+  insertRoom,
+  setRoomAboveOrBelow,
+} from "../slice/levelEditorSlice";
+import { LazyEditorMapInsertButtonDecorator } from "./LazyEditorMapInsertButtonDecorator";
 import { useEditorMapData } from "./useEditorMapData";
+
+const keyToUnitVector = {
+  ArrowLeft: "left",
+  ArrowRight: "right",
+  ArrowUp: "away",
+  ArrowDown: "towards",
+  PageUp: "up",
+  PageDown: "down",
+} as const satisfies { [K in Key]?: keyof typeof unitVectors };
+
+type NavigationKey = keyof typeof keyToUnitVector;
+
+const isNavigationKey = (key: string): key is NavigationKey =>
+  key in keyToUnitVector;
+
+const navigateToAdjacentRoom = (
+  key: NavigationKey,
+  gridPositions: SortedObjectOfRoomGridPositionSpecs<EditorRoomId>,
+) => {
+  const { roomId, subRoomId } = store.getState().levelEditor.currentlyEditing;
+  const direction = keyToUnitVector[key];
+  if (!direction) {
+    return;
+  }
+
+  const currentRoomPosition = valuesIter(gridPositions).find(
+    (spec) => spec.roomId === roomId && spec.subRoomId === subRoomId,
+  )?.gridPosition;
+
+  if (!currentRoomPosition) {
+    return;
+  }
+
+  const targetPosition = addXyz(currentRoomPosition, unitVectors[direction]);
+
+  const targetSpec = valuesIter(gridPositions).find((spec) =>
+    xyzEqual(spec.gridPosition, targetPosition),
+  );
+  if (!targetSpec) {
+    return;
+  }
+
+  store.dispatch(
+    changeToRoom({
+      roomId: targetSpec.roomId,
+      subRoomId: targetSpec.subRoomId,
+    }),
+  );
+
+  requestAnimationFrame(() => {
+    document
+      .querySelector<SVGPathElement>(
+        `[data-room-click="${targetSpec.roomId}/${targetSpec.subRoomId}"]`,
+      )
+      ?.focus();
+  });
+};
+
+const insertInDirection = (key: NavigationKey) => {
+  const direction = keyToUnitVector[key];
+  switch (direction) {
+    case "left":
+    case "right":
+    case "away":
+    case "towards":
+      store.dispatch(insertRoom({ direction }));
+      break;
+    case "up":
+    case "down":
+      store.dispatch(
+        setRoomAboveOrBelow({
+          direction: direction === "up" ? "above" : "below",
+          createNew: true,
+        }),
+      );
+      break;
+  }
+};
+
+const editorClickableRoomDecorator = createClickableRoomDecorator<EditorRoomId>(
+  (roomId, subRoomId) => {
+    store.dispatch(changeToRoom({ roomId, subRoomId }));
+  },
+);
+
+const editorClickableAreaDecorators: WrapClickableRoomDecoratorComponent<EditorRoomId>[] =
+  [
+    LazyMapRoomTooltipDecorator as WrapClickableRoomDecoratorComponent<EditorRoomId>,
+    editorClickableRoomDecorator,
+  ];
+
+const editorPostfixDecorators = [LazyEditorMapInsertButtonDecorator];
 
 export const EditorMap = () => {
   const {
@@ -30,20 +138,29 @@ export const EditorMap = () => {
   }
 
   if (mapContainerHeight === 0) {
-    // probably means the panel the map is on has been minimised - render nothing:
     return null;
   }
 
   return (
     <div
-      className={`h-full overflow-y-auto scale-editor bg-editor-checkerboard scrollbar scrollbar-w-1 scrollbar-track-pureBlack scrollbar-thumb-metallicBlue`}
+      className={`h-full overflow-y-auto scale-editor bg-editor-checkerboard scrollbar scrollbar-w-1 scrollbar-track-pureBlack scrollbar-thumb-metallicBlue outline-none`}
       ref={mapContainerRef}
+      tabIndex={0}
+      onKeyDown={(e: KeyboardEvent) => {
+        if (isNavigationKey(e.key)) {
+          e.preventDefault();
+          if (e.altKey) {
+            insertInDirection(e.key);
+          } else {
+            navigateToAdjacentRoom(e.key, mapData.gridPositions);
+          }
+        }
+      }}
     >
       <MapSvg<EditorRoomId>
         containerWidth={mapContainerWidth}
-        onRoomClick={(roomId) => {
-          store.dispatch(changeToRoom(roomId));
-        }}
+        clickableAreaDecorators={editorClickableAreaDecorators}
+        postfixDecorators={editorPostfixDecorators}
         {...mapData}
       />
     </div>

--- a/src/editor/EditorMap/EditorMapInsertButtonDecorator.tsx
+++ b/src/editor/EditorMap/EditorMapInsertButtonDecorator.tsx
@@ -1,0 +1,319 @@
+import type { PropsWithChildren, Ref } from "react";
+
+import type { RoomDecoratorProps } from "../../game/components/dialogs/menuDialog/dialogs/map/RoomDecoratorProps";
+import type { Boundaries } from "../../game/components/dialogs/menuDialog/dialogs/map/roomGridPositions";
+import type { SortedObjectOfRoomGridPositionSpecs } from "../../game/components/dialogs/menuDialog/dialogs/map/sortRoomGridPositions";
+import type { EditorRoomId } from "../editorTypes";
+
+import { roomGridSizeXY } from "../../game/components/dialogs/menuDialog/dialogs/map/mapConstants";
+import { BitmapText } from "../../game/components/tailwindSprites/BitmapText";
+import { projectWorldXyzToScreenXy } from "../../game/render/projections";
+import { editorStore, useEditorAppSelector } from "../../store/store";
+import { valuesIter } from "../../utils/entries";
+import { useElementSize } from "../../utils/react/useElementSize";
+import { unitVectors } from "../../utils/vectors/unitVectors";
+import {
+  addXyz,
+  type Direction8Xyz,
+  xyzEqual,
+} from "../../utils/vectors/vectors";
+import { selectCurrentRoomFromLevelEditorState } from "../slice/levelEditorSelectors";
+import { insertRoom, setRoomAboveOrBelow } from "../slice/levelEditorSlice";
+import { ToolbarButton } from "../toolbar/buttons/ToolbarButton";
+
+const half = roomGridSizeXY / 2;
+const xyOutwardOffset = 52;
+const zOutwardOffset = 44;
+
+const centre = projectWorldXyzToScreenXy({ x: half, y: half });
+
+type InsertDirection =
+  | "above"
+  | "away"
+  | "below"
+  | "left"
+  | "right"
+  | "towards";
+
+const allDirections: InsertDirection[] = [
+  "left",
+  "right",
+  "away",
+  "towards",
+  "above",
+  "below",
+];
+
+const directionToUnitVector: Record<InsertDirection, Direction8Xyz> = {
+  left: "left",
+  right: "right",
+  away: "away",
+  towards: "towards",
+  above: "up",
+  below: "down",
+};
+
+const rightOff = projectWorldXyzToScreenXy({ x: -xyOutwardOffset });
+const leftOff = projectWorldXyzToScreenXy({ x: xyOutwardOffset });
+const towardsOff = projectWorldXyzToScreenXy({ y: -xyOutwardOffset });
+const awayOff = projectWorldXyzToScreenXy({ y: xyOutwardOffset });
+const aboveOff = projectWorldXyzToScreenXy({ z: zOutwardOffset });
+const belowOff = projectWorldXyzToScreenXy({ z: -zOutwardOffset });
+
+const screenPositions: Record<InsertDirection, { x: number; y: number }> = {
+  right: { x: centre.x + rightOff.x, y: centre.y + rightOff.y },
+  left: { x: centre.x + leftOff.x, y: centre.y + leftOff.y },
+  towards: { x: centre.x + towardsOff.x, y: centre.y + towardsOff.y },
+  away: { x: centre.x + awayOff.x, y: centre.y + awayOff.y },
+  above: { x: centre.x + aboveOff.x, y: centre.y + aboveOff.y },
+  below: { x: centre.x + belowOff.x, y: centre.y + belowOff.y },
+};
+
+const isXyConnected = (
+  direction: "away" | "left" | "right" | "towards",
+  boundaries: Boundaries,
+): boolean => boundaries[direction] === "doorway";
+
+const hasRoomAtTarget = (
+  direction: InsertDirection,
+  roomId: EditorRoomId,
+  subRoomId: string,
+  allGridPositions: SortedObjectOfRoomGridPositionSpecs<EditorRoomId>,
+): boolean => {
+  const currentSpec = valuesIter(allGridPositions).find(
+    (spec) => spec.roomId === roomId && spec.subRoomId === subRoomId,
+  );
+  if (!currentSpec) {
+    return false;
+  }
+
+  const targetPosition = addXyz(
+    currentSpec.gridPosition,
+    unitVectors[directionToUnitVector[direction]],
+  );
+  return valuesIter(allGridPositions).some(
+    (spec) =>
+      spec.roomId !== roomId && xyzEqual(spec.gridPosition, targetPosition),
+  );
+};
+
+type ButtonMode = "add" | "door" | "floor" | "insert";
+
+const getXyButtonMode = (
+  direction: "away" | "left" | "right" | "towards",
+  boundaries: Boundaries,
+  roomId: EditorRoomId,
+  subRoomId: string,
+  allGridPositions: SortedObjectOfRoomGridPositionSpecs<EditorRoomId>,
+): ButtonMode => {
+  if (isXyConnected(direction, boundaries)) {
+    return "insert";
+  }
+  if (hasRoomAtTarget(direction, roomId, subRoomId, allGridPositions)) {
+    return "door";
+  }
+  return "add";
+};
+
+const getZButtonMode = (
+  direction: "above" | "below",
+  hasRoomVertically: boolean,
+  roomId: EditorRoomId,
+  subRoomId: string,
+  allGridPositions: SortedObjectOfRoomGridPositionSpecs<EditorRoomId>,
+): ButtonMode => {
+  if (hasRoomVertically) {
+    return "insert";
+  }
+  if (hasRoomAtTarget(direction, roomId, subRoomId, allGridPositions)) {
+    return "floor";
+  }
+  return "add";
+};
+
+const buttonLabels: Record<ButtonMode, string> = {
+  insert: "i",
+  door: "d",
+  floor: "f",
+  add: "+",
+};
+
+const directionNames: Record<InsertDirection, string> = {
+  left: "**↖** *left* of",
+  right: "**↘** *right* of",
+  away: "**↗** *behind*",
+  towards: "**↙** *in front* of",
+  above: "**⬆** *above*",
+  below: "**⬇** *below*",
+};
+
+const tooltipForMode = (
+  mode: ButtonMode,
+  direction: InsertDirection,
+): string => {
+  const where = directionNames[direction];
+  switch (mode) {
+    case "add":
+      return `*Add* a room ${where} this one`;
+    case "door":
+      return `Add a *door* to join these rooms`;
+    case "floor":
+      return direction === "above" ?
+          `Remove the *floor above*`
+        : `Remove the *floor*`;
+    case "insert":
+      return `*Insert* a room ${where} this one`;
+  }
+};
+
+const dispatchForDirection = (direction: InsertDirection) => {
+  switch (direction) {
+    case "left":
+    case "right":
+    case "away":
+    case "towards":
+      editorStore.dispatch(insertRoom({ direction }));
+      break;
+    case "above":
+    case "below":
+      editorStore.dispatch(setRoomAboveOrBelow({ direction, createNew: true }));
+      break;
+  }
+};
+
+type ButtonAtPositionProps = PropsWithChildren<{
+  x: number;
+  y: number;
+  buttonW: number;
+  buttonH: number;
+  foRef?: Ref<SVGForeignObjectElement>;
+}>;
+
+const ButtonAtPosition = ({
+  x,
+  y,
+  buttonW,
+  buttonH,
+  foRef,
+  children,
+}: ButtonAtPositionProps) => (
+  <foreignObject
+    ref={foRef}
+    x={x - buttonW / 2}
+    y={y - buttonH / 2}
+    width={buttonW}
+    height={buttonH}
+  >
+    {children}
+  </foreignObject>
+);
+
+const EditorMapInsertButtonDecorator = ({
+  roomId,
+  subRoomId,
+  boundaries,
+  isCurrentSubRoom,
+  allGridPositions,
+}: RoomDecoratorProps<EditorRoomId>) => {
+  const {
+    ref: measureRef,
+    width: buttonW,
+    height: buttonH,
+  } = useElementSize<SVGForeignObjectElement>({ measureFirstChild: true });
+
+  const hasRoomAbove = useEditorAppSelector(
+    (state) =>
+      selectCurrentRoomFromLevelEditorState(state.levelEditor).roomAbove !==
+      undefined,
+  );
+  const hasRoomBelow = useEditorAppSelector(
+    (state) =>
+      selectCurrentRoomFromLevelEditorState(state.levelEditor).roomBelow !==
+      undefined,
+  );
+
+  if (!isCurrentSubRoom) {
+    return null;
+  }
+
+  const w = buttonW ?? 0;
+  const h = buttonH ?? 0;
+
+  const getModeForDirection = (direction: InsertDirection): ButtonMode => {
+    switch (direction) {
+      case "left":
+      case "right":
+      case "away":
+      case "towards":
+        return getXyButtonMode(
+          direction,
+          boundaries,
+          roomId,
+          subRoomId,
+          allGridPositions,
+        );
+      case "above":
+        return getZButtonMode(
+          direction,
+          hasRoomAbove,
+          roomId,
+          subRoomId,
+          allGridPositions,
+        );
+      case "below":
+        return getZButtonMode(
+          direction,
+          hasRoomBelow,
+          roomId,
+          subRoomId,
+          allGridPositions,
+        );
+    }
+  };
+
+  const visibleDirections = allDirections.filter((direction) => {
+    switch (direction) {
+      case "left":
+      case "right":
+      case "away":
+      case "towards":
+        return boundaries[direction] !== "open";
+      case "above":
+      case "below":
+        return true;
+    }
+  });
+
+  return (
+    <>
+      {visibleDirections.map((direction, i) => {
+        const { x, y } = screenPositions[direction];
+        const mode = getModeForDirection(direction);
+
+        return (
+          <ButtonAtPosition
+            key={direction}
+            x={x}
+            y={y}
+            buttonW={w}
+            buttonH={h}
+            foRef={i === 0 ? measureRef : undefined}
+          >
+            <ToolbarButton
+              small
+              className="block"
+              onClick={() => dispatchForDirection(direction)}
+              tooltipContent={tooltipForMode(mode, direction)}
+            >
+              <BitmapText className="relative leading-none text-white">
+                {buttonLabels[mode]}
+              </BitmapText>
+            </ToolbarButton>
+          </ButtonAtPosition>
+        );
+      })}
+    </>
+  );
+};
+
+export default EditorMapInsertButtonDecorator;

--- a/src/editor/EditorMap/LazyEditorMapInsertButtonDecorator.ts
+++ b/src/editor/EditorMap/LazyEditorMapInsertButtonDecorator.ts
@@ -1,0 +1,13 @@
+import { lazy } from "react";
+
+import type { PostfixRoomDecoratorComponent } from "../../game/components/dialogs/menuDialog/dialogs/map/RoomDecoratorProps";
+import type { EditorRoomId } from "../editorTypes";
+
+import { importOnce } from "../../utils/importOnce";
+
+const importEditorMapInsertButtonDecorator = importOnce(
+  () => import("./EditorMapInsertButtonDecorator"),
+);
+
+export const LazyEditorMapInsertButtonDecorator: PostfixRoomDecoratorComponent<EditorRoomId> =
+  lazy(importEditorMapInsertButtonDecorator);

--- a/src/editor/EditorMap/useEditorMapData.tsx
+++ b/src/editor/EditorMap/useEditorMapData.tsx
@@ -21,19 +21,13 @@ export const useEditorMapData = (): MapData<EditorRoomId> | MapDataError => {
   const campaign = useEditorAppSelector(
     (state) => state.levelEditor.campaignInProgress,
   );
-  const curRoomSubroom = useEditorAppSelector((state) => {
-    const roomJson = selectCurrentEditingRoomJson(state);
-    const subRooms = roomJson.meta?.subRooms;
-    // find any sub-room for the current room:
-    return (subRooms && Object.keys(subRooms)[0]) ?? "*";
-  });
+
   const curRoomScenery = useEditorAppSelector((state) => {
     const roomJson = selectCurrentEditingRoomJson(state);
     return roomJson.planet;
   });
-  const curRoomEditingRoomId = useEditorAppSelector(
-    (state) => state.levelEditor.currentlyEditingRoomId,
-  );
+  const { roomId: curRoomEditingRoomId, subRoomId: curRoomSubroom } =
+    useEditorAppSelector((state) => state.levelEditor.currentlyEditing);
 
   return useMemo(() => {
     try {
@@ -49,6 +43,7 @@ export const useEditorMapData = (): MapData<EditorRoomId> | MapDataError => {
       return {
         mapBounds: findMapBounds(positions),
         curRoomId: curRoomEditingRoomId,
+        curSubRoomId: curRoomSubroom,
         gridPositions: sortedObjectOfPositions,
         // TODO: not sure if this applies for the editor, maybe should be optional
         currentCharacterName: "head",

--- a/src/editor/JsonRoomEditor/JsonRoomEditor.tsx
+++ b/src/editor/JsonRoomEditor/JsonRoomEditor.tsx
@@ -16,7 +16,7 @@ const JsonRoomEditor = () => {
     null,
   );
   const currentlyEditingRoomId = useEditorAppSelector(
-    (state) => state.levelEditor.currentlyEditingRoomId,
+    (state) => state.levelEditor.currentlyEditing.roomId,
   );
 
   const monacoLoaded = !!useLoadMonaco();

--- a/src/editor/JsonRoomEditor/suggestions/suggestionPatterns.ts
+++ b/src/editor/JsonRoomEditor/suggestions/suggestionPatterns.ts
@@ -24,7 +24,7 @@ export type SuggestionPatterns = Record<string, SuggestionGenerator>;
  */
 const getOtherRoomIds = (storeState: EditorRootState): string[] =>
   Object.keys(storeState.levelEditor.campaignInProgress.rooms).filter(
-    (roomId) => roomId !== storeState.levelEditor.currentlyEditingRoomId,
+    (roomId) => roomId !== storeState.levelEditor.currentlyEditing.roomId,
   );
 
 /**

--- a/src/editor/JsonRoomEditor/useUpdateJsonTextWhenStoreChanges.ts
+++ b/src/editor/JsonRoomEditor/useUpdateJsonTextWhenStoreChanges.ts
@@ -22,7 +22,9 @@ const updateTextNow = (
   }
 
   const roomJson = selectCurrentEditingRoomJson(state);
-  const { currentlyEditingRoomId } = state.levelEditor;
+  const {
+    currentlyEditing: { roomId: currentlyEditingRoomId },
+  } = state.levelEditor;
 
   if (roomJson === undefined || !currentlyEditingRoomId) {
     return;
@@ -109,7 +111,7 @@ const useUpdateTextWhenJsonChangesInSameRoom = (
 ) => {
   const currentRoomJson = useEditorAppSelector(selectCurrentEditingRoomJson);
   const currentlyEditingRoomId = useEditorAppSelector(
-    (state) => state.levelEditor.currentlyEditingRoomId,
+    (state) => state.levelEditor.currentlyEditing.roomId,
   );
   const previousRoomIdRef = useRef<string | undefined>(undefined);
 
@@ -146,7 +148,7 @@ const useCreateDocumentsInMonacoWhenCurrentRoomChanges = (
   monaco: null | typeof Monaco,
 ) => {
   const currentlyEditingRoomId = useEditorAppSelector(
-    (state) => state.levelEditor.currentlyEditingRoomId,
+    (state) => state.levelEditor.currentlyEditing.roomId,
   );
 
   useEffect(() => {

--- a/src/editor/RoomEditingArea/interactivity/useRoomEditorInteractivity.tsx
+++ b/src/editor/RoomEditingArea/interactivity/useRoomEditorInteractivity.tsx
@@ -96,7 +96,7 @@ export const useRoomEditorInteractivity = (
       const storeState = editorStore.getState();
       const roomState = selectEditorRoomState(storeState);
 
-      if (roomState.id !== storeState.levelEditor.currentlyEditingRoomId) {
+      if (roomState.id !== storeState.levelEditor.currentlyEditing.roomId) {
         return;
       }
 

--- a/src/editor/slice/inPlaceMutators/addDoorInPlace.ts
+++ b/src/editor/slice/inPlaceMutators/addDoorInPlace.ts
@@ -2,12 +2,13 @@ import { findSubRoomForItem } from "../../../game/components/dialogs/menuDialog/
 import { roomGridPositions } from "../../../game/components/dialogs/menuDialog/dialogs/map/roomGridPositions";
 import { nextItemId } from "../../../model/inPlaceMutators/nextItemId";
 import { typePrefix } from "../../../model/json/typePrefix";
-import { iterateRoomJsonItemsWithIds } from "../../../model/RoomJson";
 import { keys } from "../../../utils/entries";
 import { unitVectors } from "../../../utils/vectors/unitVectors";
 import {
   type DirectionXy4,
   oppositeDirection,
+  originXy,
+  type Xy,
   type Xyz,
   xyzEqual,
 } from "../../../utils/vectors/vectors";
@@ -19,6 +20,12 @@ import {
 import { type ItemTool } from "../../RoomEditingArea/interactivity/Tool";
 import { selectCurrentRoomFromLevelEditorState } from "../levelEditorSelectors";
 import { type LevelEditorState } from "../levelEditorSlice";
+import {
+  roomFloorMaxX,
+  roomFloorMaxY,
+  roomFloorMinX,
+  roomFloorMinY,
+} from "../roomJsonSelectors";
 import { addItemInPlace } from "./addItemInPlace";
 import { addNewRoomInPlace } from "./addNewRoomInPlace";
 import { cutHoleInWallsForDoorsInPlace } from "./cutHoleInWallsForDoorsInPlace";
@@ -68,49 +75,19 @@ const getDestinationRoom = ({
     : undefined;
 };
 
-const roomFloorMinY = (roomJson: EditorRoomJson): number =>
-  iterateRoomJsonItemsWithIds(roomJson.items, "floor").reduce(
-    (min, [, item]) => {
-      const itemTop = item.position.y;
-      return Math.min(min, itemTop);
-    },
-    Number.POSITIVE_INFINITY,
-  );
-const roomFloorMaxY = (roomJson: EditorRoomJson): number =>
-  iterateRoomJsonItemsWithIds(roomJson.items, "floor").reduce(
-    (max, [, item]) => {
-      const itemBottom = item.position.y + item.config.times.y;
-      return Math.max(max, itemBottom);
-    },
-    Number.NEGATIVE_INFINITY,
-  );
-const roomFloorMinX = (roomJson: EditorRoomJson): number =>
-  iterateRoomJsonItemsWithIds(roomJson.items, "floor").reduce(
-    (min, [, item]) => {
-      const itemTop = item.position.x;
-      return Math.min(min, itemTop);
-    },
-    Number.POSITIVE_INFINITY,
-  );
-const roomFloorMaxX = (roomJson: EditorRoomJson): number =>
-  iterateRoomJsonItemsWithIds(roomJson.items, "floor").reduce(
-    (max, [, item]) => {
-      const itemBottom = item.position.x + item.config.times.x;
-      return Math.max(max, itemBottom);
-    },
-    Number.NEGATIVE_INFINITY,
-  );
-
 export const addReturnDoorInPlace = ({
   state,
   fromRoomJson,
   toRoomJson,
   outgoingDoorEntry: [outgoingDoorId, outgoingDoor],
+  outgoingDoorRelativeTo = originXy,
 }: {
   state: LevelEditorState;
   fromRoomJson: EditorRoomJson;
   toRoomJson: EditorRoomJson;
   outgoingDoorEntry: [EditorRoomItemId, EditorJsonItem<"door">];
+  /** origin to subtract from the outgoing door's position for the return door's non-directional axis */
+  outgoingDoorRelativeTo?: Xy;
 }) => {
   const outgoingDirection = outgoingDoor.config.direction;
   const outgoingPosition = outgoingDoor.position;
@@ -128,13 +105,11 @@ export const addReturnDoorInPlace = ({
     x:
       outgoingDirection === "left" ? roomFloorMinX(toRoomJson)
       : outgoingDirection === "right" ? roomFloorMaxX(toRoomJson)
-        // line up to match the door we just added (this assumes the room going to is big enough)
-      : outgoingPosition.x,
+      : outgoingPosition.x - outgoingDoorRelativeTo.x,
     y:
       outgoingDirection === "away" ? roomFloorMinY(toRoomJson)
       : outgoingDirection === "towards" ? roomFloorMaxY(toRoomJson)
-        // line up to match the door we just added (this assumes the room going to is big enough)
-      : outgoingPosition.y,
+      : outgoingPosition.y - outgoingDoorRelativeTo.y,
     z: outgoingPosition.z,
   };
 

--- a/src/editor/slice/inPlaceMutators/addItemInPlace.ts
+++ b/src/editor/slice/inPlaceMutators/addItemInPlace.ts
@@ -67,7 +67,7 @@ export const addItemInPlace = <T extends JsonItemType = JsonItemType>(
 export const roomEditTarget = (
   state: LevelEditorState,
   isPreview: boolean,
-  roomId: EditorRoomId = state.currentlyEditingRoomId,
+  roomId: EditorRoomId = state.currentlyEditing.roomId,
 ): EditorRoomJsonItems | PreviewedRoomItemEdits => {
   return isPreview ?
       state.previewedEdits

--- a/src/editor/slice/inPlaceMutators/changeCurrentRoomInPlace.ts
+++ b/src/editor/slice/inPlaceMutators/changeCurrentRoomInPlace.ts
@@ -1,30 +1,48 @@
-import { type EditorRoomId } from "../../editorTypes";
+import type { RoomJson } from "../../../model/RoomJson";
+import type { EditorRoomId } from "../../editorTypes";
+import type { LevelEditorState } from "../levelEditorSlice";
+
 import { initialLevelEditorSliceState } from "../initialLevelEditorSliceState";
-import { type LevelEditorState } from "../levelEditorSlice";
+
+export const firstSubRoomId = (roomJson: RoomJson<string, string>): string => {
+  const subRoomKeys =
+    roomJson.meta?.subRooms && Object.keys(roomJson.meta.subRooms);
+  return subRoomKeys?.[0] ?? "*";
+};
 
 export const changeCurrentRoomInPlace = (
   state: LevelEditorState,
   roomId: EditorRoomId,
+  subRoomId?: string,
   noPushToHistory = false,
 ) => {
-  if (!state.campaignInProgress.rooms[roomId]) {
+  const roomJson = state.campaignInProgress.rooms[roomId];
+  if (!roomJson) {
     console.warn(`can't change to room ${roomId} - it doesn't exist`);
-    // If the room doesn't exist, we can't change to it
     return;
   }
-  if (!noPushToHistory) {
-    // put the old currently editing room to the back history so user
-    // can return to it later:
-    state.editingRoomIdHistory.back.push(state.currentlyEditingRoomId);
+
+  const resolvedSubRoomId = subRoomId ?? firstSubRoomId(roomJson);
+
+  if (subRoomId !== undefined && subRoomId !== "*") {
+    const subRooms = roomJson.meta?.subRooms;
+    if (!subRooms || !(subRoomId in subRooms)) {
+      throw new Error(
+        `subRoom "${subRoomId}" does not exist in room "${roomId}"`,
+      );
+    }
   }
-  state.currentlyEditingRoomId = roomId;
+
+  if (!noPushToHistory) {
+    state.editingRoomIdHistory.back.push(state.currentlyEditing.roomId);
+  }
+  state.currentlyEditing = { roomId, subRoomId: resolvedSubRoomId };
 
   state.clickableAnnotationHovered = false;
   state.hoveredItem = undefined;
   state.selectedJsonItemIds = [];
 
   if (!noPushToHistory) {
-    // clear undo/redo history when changing room:
     state.history = initialLevelEditorSliceState.history;
   }
 };

--- a/src/editor/slice/inPlaceMutators/changeIdOfCurrentRoomInPlace.ts
+++ b/src/editor/slice/inPlaceMutators/changeIdOfCurrentRoomInPlace.ts
@@ -12,7 +12,7 @@ export const changeIdOfCurrentRoomInPlace = (
   state: LevelEditorState,
   newRoomId: EditorRoomId,
 ) => {
-  const prevRoomId = state.currentlyEditingRoomId;
+  const prevRoomId = state.currentlyEditing.roomId;
   const prevRoom = selectCurrentRoomFromLevelEditorState(state);
 
   for (const room of valuesIter(state.campaignInProgress.rooms)) {
@@ -55,7 +55,7 @@ export const changeIdOfCurrentRoomInPlace = (
   };
   delete state.campaignInProgress.rooms[prevRoomId];
 
-  state.currentlyEditingRoomId = newRoomId;
+  state.currentlyEditing.roomId = newRoomId;
 
   state.editingRoomIdHistory.back = state.editingRoomIdHistory.back.map((id) =>
     id === prevRoomId ? newRoomId : id,

--- a/src/editor/slice/inPlaceMutators/insertRoomInPlace.ts
+++ b/src/editor/slice/inPlaceMutators/insertRoomInPlace.ts
@@ -1,0 +1,311 @@
+import type {
+  EditorJsonItem,
+  EditorRoomId,
+  EditorRoomItemId,
+  EditorRoomJson,
+} from "../../editorTypes";
+import type { LevelEditorState } from "../levelEditorSlice";
+
+import { findSubRoomForItem } from "../../../game/components/dialogs/menuDialog/dialogs/map/itemIsInSubRoom";
+import { roomGridPositions } from "../../../game/components/dialogs/menuDialog/dialogs/map/roomGridPositions";
+import { nextItemId } from "../../../model/inPlaceMutators/nextItemId";
+import { exitGameRoomId } from "../../../model/json/ItemConfigMap";
+import { typePrefix } from "../../../model/json/typePrefix";
+import { iterateRoomJsonItemsWithIds } from "../../../model/RoomJson";
+import { keys, valuesIter } from "../../../utils/entries";
+import { unitVectors } from "../../../utils/vectors/unitVectors";
+import {
+  type DirectionXy4,
+  oppositeDirection,
+  type Xyz,
+  xyzEqual,
+} from "../../../utils/vectors/vectors";
+import { selectCurrentRoomFromLevelEditorState } from "../levelEditorSelectors";
+import {
+  roomFloorMaxX,
+  roomFloorMaxY,
+  roomFloorMinX,
+  roomFloorMinY,
+} from "../roomJsonSelectors";
+import { addReturnDoorInPlace } from "./addDoorInPlace";
+import { addNewRoomInPlace } from "./addNewRoomInPlace";
+import { changeCurrentRoomInPlace } from "./changeCurrentRoomInPlace";
+import { cutHoleInWallsForDoorsInPlace } from "./cutHoleInWallsForDoorsInPlace";
+
+type FloorBounds = {
+  minX: number;
+  maxX: number;
+  minY: number;
+  maxY: number;
+};
+
+const getRoomFloorBounds = (room: EditorRoomJson): FloorBounds => ({
+  minX: roomFloorMinX(room),
+  maxX: roomFloorMaxX(room),
+  minY: roomFloorMinY(room),
+  maxY: roomFloorMaxY(room),
+});
+
+const getSubRoomFloorBounds = (
+  room: EditorRoomJson,
+  subRoomId: string,
+): FloorBounds => {
+  const roomBounds = getRoomFloorBounds(room);
+
+  if (subRoomId !== "*") {
+    const subRoom = room.meta?.subRooms?.[subRoomId];
+    if (subRoom) {
+      return {
+        minX: Math.max(subRoom.physicalPosition.from.x, roomBounds.minX),
+        maxX: Math.min(subRoom.physicalPosition.to.x + 1, roomBounds.maxX),
+        minY: Math.max(subRoom.physicalPosition.from.y, roomBounds.minY),
+        maxY: Math.min(subRoom.physicalPosition.to.y + 1, roomBounds.maxY),
+      };
+    }
+  }
+
+  return roomBounds;
+};
+
+const doorPositionOnWall = (
+  /** room-wide bounds for the wall edge position */
+  roomBounds: FloorBounds,
+  doorDirection: DirectionXy4,
+  matchPosition: Xyz,
+): Xyz => ({
+  x:
+    doorDirection === "left" ? roomBounds.maxX
+    : doorDirection === "right" ? roomBounds.minX
+    : matchPosition.x,
+  y:
+    doorDirection === "away" ? roomBounds.maxY
+    : doorDirection === "towards" ? roomBounds.minY
+    : matchPosition.y,
+  z: matchPosition.z,
+});
+
+const doorWidth = 2;
+
+const wallCentreMidpoint = (bounds: FloorBounds): Xyz => ({
+  x: Math.floor((bounds.minX + bounds.maxX - doorWidth) / 2),
+  y: Math.floor((bounds.minY + bounds.maxY - doorWidth) / 2),
+  z: 0,
+});
+
+export const insertRoomInPlace = (
+  state: LevelEditorState,
+  direction: DirectionXy4,
+): void => {
+  const currentRoom = selectCurrentRoomFromLevelEditorState(state);
+  const oppositeDir = oppositeDirection(direction);
+
+  const { subRoomId } = state.currentlyEditing;
+  const currentRoomBounds = getRoomFloorBounds(currentRoom);
+  const currentSubRoomBounds = getSubRoomFloorBounds(currentRoom, subRoomId);
+
+  const currentRoomDoorsInDirection = iterateRoomJsonItemsWithIds(
+    currentRoom.items,
+    "door",
+  )
+    .filter(([, door]) => door.config.direction === direction)
+    .filter(
+      ([, door]) =>
+        findSubRoomForItem(door.position, "block", currentRoom) === subRoomId,
+    )
+    .toArray();
+
+  const inboundDoorsFromOppositeDirection: Array<{
+    doorId: EditorRoomItemId;
+    door: EditorJsonItem<"door">;
+    room: EditorRoomJson;
+  }> = [];
+
+  for (const room of valuesIter(state.campaignInProgress.rooms)) {
+    if (room.id === currentRoom.id) {
+      continue;
+    }
+    for (const [doorId, door] of iterateRoomJsonItemsWithIds(
+      room.items,
+      "door",
+    )) {
+      if (
+        door.config.toRoom === currentRoom.id &&
+        door.config.direction === oppositeDir &&
+        (door.config.meta?.toSubRoom ?? "*") === subRoomId
+      ) {
+        inboundDoorsFromOppositeDirection.push({
+          doorId: doorId as EditorRoomItemId,
+          door: door as EditorJsonItem<"door">,
+          room: room as EditorRoomJson,
+        });
+      }
+    }
+  }
+
+  const gridPositionSpecs = roomGridPositions({
+    campaign: state.campaignInProgress,
+    roomId: currentRoom.id,
+    subRoomId: state.currentlyEditing.subRoomId,
+  });
+  const targetSpec = gridPositionSpecs.find(({ gridPosition }) =>
+    xyzEqual(gridPosition, unitVectors[direction]),
+  );
+  const existingRoomAtTarget =
+    targetSpec ?
+      (state.campaignInProgress.rooms[targetSpec.roomId] as
+        | EditorRoomJson
+        | undefined)
+    : undefined;
+
+  const hasDoors =
+    currentRoomDoorsInDirection.length > 0 ||
+    inboundDoorsFromOppositeDirection.length > 0;
+
+  if (!hasDoors && existingRoomAtTarget) {
+    const centrePosition = doorPositionOnWall(
+      currentRoomBounds,
+      direction,
+      wallCentreMidpoint(currentSubRoomBounds),
+    );
+
+    const outDoorId = nextItemId(
+      keys(currentRoom.items),
+      typePrefix.door,
+    ) as EditorRoomItemId;
+    const outDoor: EditorJsonItem<"door"> = {
+      type: "door",
+      config: { toRoom: existingRoomAtTarget.id, direction },
+      position: centrePosition,
+    };
+    currentRoom.items[outDoorId] = outDoor;
+
+    cutHoleInWallsForDoorsInPlace(
+      state,
+      currentRoom.id,
+      direction,
+      centrePosition,
+      false,
+    );
+
+    addReturnDoorInPlace({
+      state,
+      fromRoomJson: currentRoom,
+      toRoomJson: existingRoomAtTarget,
+      outgoingDoorEntry: [outDoorId, outDoor],
+      outgoingDoorRelativeTo: {
+        x: currentSubRoomBounds.minX,
+        y: currentSubRoomBounds.minY,
+      },
+    });
+
+    changeCurrentRoomInPlace(state, existingRoomAtTarget.id as EditorRoomId);
+    return;
+  }
+
+  const newRoom = addNewRoomInPlace({ state, scenery: currentRoom.planet });
+
+  if (hasDoors) {
+    for (const [outDoorId, outDoor] of currentRoomDoorsInDirection) {
+      const oldToRoom = outDoor.config.toRoom;
+
+      addReturnDoorInPlace({
+        state,
+        fromRoomJson: currentRoom,
+        toRoomJson: newRoom,
+        outgoingDoorEntry: [
+          outDoorId as EditorRoomItemId,
+          outDoor as EditorJsonItem<"door">,
+        ],
+        outgoingDoorRelativeTo: {
+          x: currentSubRoomBounds.minX,
+          y: currentSubRoomBounds.minY,
+        },
+      });
+
+      outDoor.config.toRoom = newRoom.id;
+
+      if (
+        oldToRoom === exitGameRoomId ||
+        !state.campaignInProgress.rooms[oldToRoom as EditorRoomId]
+      ) {
+        const fwdDoorId = nextItemId(keys(newRoom.items), typePrefix.door);
+        const fwdDoorPosition = doorPositionOnWall(
+          getRoomFloorBounds(newRoom),
+          direction,
+          outDoor.position,
+        );
+
+        const fwdDoor: EditorJsonItem<"door"> = {
+          type: "door",
+          config: {
+            toRoom: oldToRoom,
+            direction,
+          },
+          position: fwdDoorPosition,
+        };
+        newRoom.items[fwdDoorId] = fwdDoor;
+
+        cutHoleInWallsForDoorsInPlace(
+          state,
+          newRoom.id,
+          direction,
+          fwdDoorPosition,
+          false,
+        );
+      }
+    }
+
+    for (const {
+      doorId: inDoorId,
+      door: inDoor,
+      room: inRoom,
+    } of inboundDoorsFromOppositeDirection) {
+      addReturnDoorInPlace({
+        state,
+        fromRoomJson: inRoom,
+        toRoomJson: newRoom,
+        outgoingDoorEntry: [inDoorId, inDoor],
+      });
+
+      inDoor.config.toRoom = newRoom.id;
+    }
+  } else {
+    const centrePosition = doorPositionOnWall(
+      currentRoomBounds,
+      direction,
+      wallCentreMidpoint(currentSubRoomBounds),
+    );
+
+    const outDoorId = nextItemId(
+      keys(currentRoom.items),
+      typePrefix.door,
+    ) as EditorRoomItemId;
+    const outDoor: EditorJsonItem<"door"> = {
+      type: "door",
+      config: { toRoom: newRoom.id, direction },
+      position: centrePosition,
+    };
+    currentRoom.items[outDoorId] = outDoor;
+
+    cutHoleInWallsForDoorsInPlace(
+      state,
+      currentRoom.id,
+      direction,
+      centrePosition,
+      false,
+    );
+
+    addReturnDoorInPlace({
+      state,
+      fromRoomJson: currentRoom,
+      toRoomJson: newRoom,
+      outgoingDoorEntry: [outDoorId, outDoor],
+      outgoingDoorRelativeTo: {
+        x: currentSubRoomBounds.minX,
+        y: currentSubRoomBounds.minY,
+      },
+    });
+  }
+
+  changeCurrentRoomInPlace(state, newRoom.id);
+};

--- a/src/editor/slice/initialLevelEditorSliceState.ts
+++ b/src/editor/slice/initialLevelEditorSliceState.ts
@@ -34,7 +34,7 @@ export const initialLevelEditorSliceState: LevelEditorState = {
   campaignInProgress: initialCampaign,
   // showing a 'new campaign' placeholder that has never been saved:
   remoteCampaign: undefined,
-  currentlyEditingRoomId: initialRoomId,
+  currentlyEditing: { roomId: initialRoomId, subRoomId: "*" },
   editingRoomIdHistory: {
     back: [],
     forward: [],

--- a/src/editor/slice/levelEditorSelectors.ts
+++ b/src/editor/slice/levelEditorSelectors.ts
@@ -133,7 +133,7 @@ export const selectCurrentRoomFromLevelEditorState = (
   state: LevelEditorState,
 ) =>
   state.campaignInProgress.rooms[
-    state.currentlyEditingRoomId
+    state.currentlyEditing.roomId
   ] as EditorRoomJson;
 
 export const selectRoomFromLevelEditorState = (
@@ -147,9 +147,8 @@ export const selectItemInLevelEditorState = (
   /** if not given, uses the room currently being edited */
   roomId?: EditorRoomId,
 ) =>
-  state.campaignInProgress.rooms[roomId ?? state.currentlyEditingRoomId]?.items[
-    itemId
-  ] as EditorJsonItemUnion | undefined;
+  state.campaignInProgress.rooms[roomId ?? state.currentlyEditing.roomId]
+    ?.items[itemId] as EditorJsonItemUnion | undefined;
 
 export const selectItemIsSelectedInLevelEditorState = (
   state: LevelEditorState,

--- a/src/editor/slice/levelEditorSlice.ts
+++ b/src/editor/slice/levelEditorSlice.ts
@@ -50,7 +50,10 @@ export type LevelEditorState = {
   campaignInProgress: EditorCampaign;
   /** the campaign in the db (as far as we know) - can be used to check if we have edits since the last save */
   remoteCampaign: EditorCampaign | undefined;
-  currentlyEditingRoomId: EditorRoomId;
+  currentlyEditing: {
+    roomId: EditorRoomId;
+    subRoomId: string;
+  };
   editingRoomIdHistory: {
     back: EditorRoomId[];
     forward: EditorRoomId[];
@@ -153,6 +156,7 @@ export const {
   clearRoom,
   commitCurrentPreviewedEdits,
   deleteSelected,
+  insertRoom,
   loadCampaign,
   moveOrResizeItemAsPreview,
   newCampaign,

--- a/src/editor/slice/reducers/__test__/storeStates.ts
+++ b/src/editor/slice/reducers/__test__/storeStates.ts
@@ -30,7 +30,7 @@ export const wallItemId = "testWall" as EditorRoomItemId;
 
 export const editorStateWithOneRoomWithNoItems: LevelEditorState = {
   ...initialLevelEditorSliceState,
-  currentlyEditingRoomId: testRoomId,
+  currentlyEditing: { roomId: testRoomId, subRoomId: "*" },
   campaignInProgress: {
     locator: {
       campaignName: "testCampaign",

--- a/src/editor/slice/reducers/addOrRemoveRoomReducers.test.ts
+++ b/src/editor/slice/reducers/addOrRemoveRoomReducers.test.ts
@@ -27,7 +27,7 @@ const addRooms = (draft: LevelEditorState) => {
     color: { hue: "cyan", shade: "basic" },
     items: {},
   };
-  draft.currentlyEditingRoomId = roomA;
+  draft.currentlyEditing.roomId = roomA;
 };
 
 test("removeRoom filters the deleted room from editingRoomIdHistory", () => {

--- a/src/editor/slice/reducers/addOrRemoveRoomReducers.ts
+++ b/src/editor/slice/reducers/addOrRemoveRoomReducers.ts
@@ -1,16 +1,18 @@
 import { type PayloadAction, type SliceCaseReducers } from "@reduxjs/toolkit";
 
+import type { DirectionXy4, Xy } from "../../../utils/vectors/vectors";
+import type { EditorRoomId } from "../../editorTypes";
+import type { LevelEditorState } from "../levelEditorSlice";
+
 import { exitGameRoomId } from "../../../model/json/ItemConfigMap";
 import { iterateRoomJsonItemsWithIds } from "../../../model/RoomJson";
 import { keysIter } from "../../../utils/entries";
 import { first } from "../../../utils/iterators/first";
-import { type Xy } from "../../../utils/vectors/vectors";
-import { type EditorRoomId } from "../../editorTypes";
 import { addNewRoomInPlace } from "../inPlaceMutators/addNewRoomInPlace";
 import { changeCurrentRoomInPlace } from "../inPlaceMutators/changeCurrentRoomInPlace";
+import { insertRoomInPlace } from "../inPlaceMutators/insertRoomInPlace";
 import { removeInboundRoomReferencesInPlace } from "../inPlaceMutators/removeInboundRoomReferencesInPlace";
 import { selectCurrentRoomFromLevelEditorState } from "../levelEditorSelectors";
-import { type LevelEditorState } from "../levelEditorSlice";
 
 export const addOrRemoveRoomReducers = {
   addRoom(
@@ -30,9 +32,15 @@ export const addOrRemoveRoomReducers = {
 
     changeCurrentRoomInPlace(state, newRoom.id);
   },
+  insertRoom(
+    state,
+    { payload: { direction } }: PayloadAction<{ direction: DirectionXy4 }>,
+  ) {
+    insertRoomInPlace(state, direction);
+  },
   removeRoom(state) {
     const currentRoom =
-      state.campaignInProgress.rooms[state.currentlyEditingRoomId];
+      state.campaignInProgress.rooms[state.currentlyEditing.roomId];
     // to stay near the deleted room, find another room adjacent to it:
     const doorOrTeleporterEntry =
       first(iterateRoomJsonItemsWithIds(currentRoom.items, "door")) ??
@@ -40,7 +48,7 @@ export const addOrRemoveRoomReducers = {
 
     const nextRoom = (doorOrTeleporterEntry?.[1].config.toRoom ??
       keysIter(state.campaignInProgress.rooms).find(
-        (roomId) => roomId !== state.currentlyEditingRoomId,
+        (roomId) => roomId !== state.currentlyEditing.roomId,
       )) as EditorRoomId | undefined;
 
     if (nextRoom === undefined || nextRoom === exitGameRoomId) {
@@ -48,7 +56,7 @@ export const addOrRemoveRoomReducers = {
       return;
     }
 
-    const deletedRoomId = state.currentlyEditingRoomId;
+    const deletedRoomId = state.currentlyEditing.roomId;
     changeCurrentRoomInPlace(state, nextRoom);
     delete state.campaignInProgress.rooms[deletedRoomId];
     removeInboundRoomReferencesInPlace(state, deletedRoomId);

--- a/src/editor/slice/reducers/applyItemToolReducers.test.ts
+++ b/src/editor/slice/reducers/applyItemToolReducers.test.ts
@@ -445,7 +445,7 @@ describe("applying tools", () => {
 
   const currentRoom = (state: LevelEditorState) =>
     state.campaignInProgress.rooms[
-      state.currentlyEditingRoomId!
+      state.currentlyEditing.roomId!
     ] as EditorRoomJson;
 
   const findFloor = (state: LevelEditorState) => {

--- a/src/editor/slice/reducers/campaignManagementReducers.ts
+++ b/src/editor/slice/reducers/campaignManagementReducers.ts
@@ -15,7 +15,7 @@ export const campaignManagementReducers = {
         initialLevelEditorSliceState,
         ...levelEditorSliceNonPersistedFields,
         "campaignInProgress",
-        "currentlyEditingRoomId",
+        "currentlyEditing",
         "remoteCampaign",
         "history",
         "editingRoomIdHistory",

--- a/src/editor/slice/reducers/changeRoomReducers.ts
+++ b/src/editor/slice/reducers/changeRoomReducers.ts
@@ -9,12 +9,23 @@ import { changeCurrentRoomInPlace } from "../inPlaceMutators/changeCurrentRoomIn
 import { type LevelEditorState } from "../levelEditorSlice";
 
 export const changeRoomReducers = {
-  changeToRoom(_state, { payload: roomId }: PayloadAction<EditorRoomId>) {
+  changeToRoom(
+    _state,
+    {
+      payload,
+    }: PayloadAction<
+      { roomId: EditorRoomId; subRoomId?: string } | EditorRoomId
+    >,
+  ) {
     // DO REMOVE CAST - for some reason, a severe typescript performance issue was narrowed
     // down specifically to the WritableDraft<> type here - immer was making ts slow when we assigned to
     // the wrapped type. Since the normal type isn't readonly, this wrapping isn't needed anyway
     const state = _state as LevelEditorState;
-    changeCurrentRoomInPlace(state, roomId);
+    const { roomId, subRoomId } =
+      typeof payload === "string" ?
+        { roomId: payload, subRoomId: undefined }
+      : payload;
+    changeCurrentRoomInPlace(state, roomId, subRoomId);
   },
 
   roomBack(_state, { payload: n = 1 }: PayloadAction<number | undefined>) {
@@ -28,14 +39,14 @@ export const changeRoomReducers = {
       return;
     }
 
-    editingRoomIdHistory.forward.push(state.currentlyEditingRoomId);
+    editingRoomIdHistory.forward.push(state.currentlyEditing.roomId);
     for (let i = 0; i < n - 1; i++) {
       editingRoomIdHistory.forward.push(
         editingRoomIdHistory.back.pop() as EditorRoomId,
       );
     }
     const targetRoomId = editingRoomIdHistory.back.pop() as EditorRoomId;
-    changeCurrentRoomInPlace(state, targetRoomId, true);
+    changeCurrentRoomInPlace(state, targetRoomId, undefined, true);
   },
 
   roomForward(_state, { payload: n = 1 }: PayloadAction<number | undefined>) {
@@ -49,14 +60,14 @@ export const changeRoomReducers = {
       return;
     }
 
-    editingRoomIdHistory.back.push(state.currentlyEditingRoomId);
+    editingRoomIdHistory.back.push(state.currentlyEditing.roomId);
     for (let i = 0; i < n - 1; i++) {
       editingRoomIdHistory.back.push(
         editingRoomIdHistory.forward.pop() as EditorRoomId,
       );
     }
     const targetRoomId = editingRoomIdHistory.forward.pop() as EditorRoomId;
-    changeCurrentRoomInPlace(state, targetRoomId, true);
+    changeCurrentRoomInPlace(state, targetRoomId, undefined, true);
   },
 } satisfies SliceCaseReducers<LevelEditorState>;
 

--- a/src/editor/slice/reducers/editRoomReducers.test.ts
+++ b/src/editor/slice/reducers/editRoomReducers.test.ts
@@ -18,6 +18,7 @@ import {
   deleteSelected,
   type LevelEditorState,
   roomJsonEdited,
+  setRoomAboveOrBelow,
   setSelectedItemsInRoom,
   setTool,
 } from "../levelEditorSlice";
@@ -425,7 +426,7 @@ describe('editing a door\'s "toRoom" config provides convenience methods to main
 
     const state: LevelEditorState = {
       ...editorStateWithOneRoomWithNoItems,
-      currentlyEditingRoomId: roomA,
+      currentlyEditing: { roomId: roomA, subRoomId: "*" },
       campaignInProgress: {
         ...editorStateWithOneRoomWithNoItems.campaignInProgress,
         rooms: {
@@ -519,5 +520,77 @@ describe('editing a door\'s "toRoom" config provides convenience methods to main
     // C's right door should not have been modified:
     expect(cRightDoor.config.toRoom).toBe(roomB);
     expect(cRightDoor.config.direction).toBe("right");
+  });
+});
+
+describe("setRoomAboveOrBelow", () => {
+  test("createNew with no existing room above creates and links bidirectionally", () => {
+    const result = reduceLevelEditorActions(
+      editorStateWithOneRoomWithNoItems,
+      setRoomAboveOrBelow({ direction: "above", createNew: true }),
+    );
+
+    const originalRoom = result.campaignInProgress.rooms[testRoomId];
+    const newRoomId = originalRoom.roomAbove!;
+    const newRoom = result.campaignInProgress.rooms[newRoomId];
+
+    expect(newRoom).toBeDefined();
+    expect(newRoom.roomBelow).toBe(testRoomId);
+  });
+
+  test("createNew navigates to the newly created room", () => {
+    const result = reduceLevelEditorActions(
+      editorStateWithOneRoomWithNoItems,
+      setRoomAboveOrBelow({ direction: "above", createNew: true }),
+    );
+
+    expect(result.currentlyEditing.roomId).not.toBe(testRoomId);
+    const originalRoom = result.campaignInProgress.rooms[testRoomId];
+    expect(result.currentlyEditing.roomId).toBe(originalRoom.roomAbove);
+  });
+
+  test("createNew splices between existing rooms", () => {
+    const roomB = "roomB" as EditorRoomId;
+    const stateWithRoomAbove: LevelEditorState = produce(
+      editorStateWithOneRoomWithNoItems,
+      (draft) => {
+        draft.campaignInProgress.rooms[roomB] = {
+          id: roomB,
+          planet: "blacktooth",
+          color: { hue: "cyan", shade: "basic" },
+          items: {},
+          roomBelow: testRoomId,
+        };
+        draft.campaignInProgress.rooms[testRoomId].roomAbove = roomB;
+      },
+    );
+
+    const result = reduceLevelEditorActions(
+      stateWithRoomAbove,
+      setRoomAboveOrBelow({ direction: "above", createNew: true }),
+    );
+
+    const originalRoom = result.campaignInProgress.rooms[testRoomId];
+    const newRoomId = originalRoom.roomAbove!;
+    const newRoom = result.campaignInProgress.rooms[newRoomId];
+    const roomBResult = result.campaignInProgress.rooms[roomB];
+
+    expect(newRoom.roomBelow).toBe(testRoomId);
+    expect(newRoom.roomAbove).toBe(roomB);
+    expect(roomBResult.roomBelow).toBe(newRoomId);
+  });
+
+  test("createNew gives the new sandwiched room a 'none' floor", () => {
+    const result = reduceLevelEditorActions(
+      editorStateWithOneRoomWithNoItems,
+      setRoomAboveOrBelow({ direction: "below", createNew: true }),
+    );
+
+    const originalRoom = result.campaignInProgress.rooms[testRoomId];
+    const floors = [...roomJsonItemsIterable(originalRoom)].filter(
+      (item) => item.type === "floor",
+    );
+
+    expect(floors.every((f) => f.config.floorType === "none")).toBe(true);
   });
 });

--- a/src/editor/slice/reducers/editRoomReducers.ts
+++ b/src/editor/slice/reducers/editRoomReducers.ts
@@ -22,6 +22,7 @@ import {
 } from "../../editorTypes";
 import { addReturnDoorInPlace } from "../inPlaceMutators/addDoorInPlace";
 import { addNewRoomInPlace } from "../inPlaceMutators/addNewRoomInPlace";
+import { changeCurrentRoomInPlace } from "../inPlaceMutators/changeCurrentRoomInPlace";
 import { changeIdOfCurrentRoomInPlace } from "../inPlaceMutators/changeIdOfCurrentRoomInPlace";
 import { consolidateCurrentRoomInPlace } from "../inPlaceMutators/consolidateCurrentRoomInPlace";
 import { deleteItemInPlace } from "../inPlaceMutators/deleteItemInPlace";
@@ -76,7 +77,7 @@ export const editRoomReducers = {
     const state = _state as LevelEditorState;
 
     const target =
-      state.campaignInProgress.rooms[state.currentlyEditingRoomId].color;
+      state.campaignInProgress.rooms[state.currentlyEditing.roomId].color;
 
     pushUndoInPlace(state);
     Object.assign(target, colour);
@@ -109,8 +110,8 @@ export const editRoomReducers = {
     const state = _state as LevelEditorState;
     pushUndoInPlace(state);
     const { rooms } = state.campaignInProgress;
-    const prevRoomJson = rooms[state.currentlyEditingRoomId];
-    rooms[state.currentlyEditingRoomId] = newRoomJson;
+    const prevRoomJson = rooms[state.currentlyEditing.roomId];
+    rooms[state.currentlyEditing.roomId] = newRoomJson;
 
     // selected items may no longer exist in the room after reloading - remove these selections:
     const selectedJsonItemIdsThatStillExist = state.selectedJsonItemIds.filter(
@@ -126,7 +127,7 @@ export const editRoomReducers = {
       state.selectedJsonItemIds = selectedJsonItemIdsThatStillExist;
     }
 
-    if (newRoomJson.id !== state.currentlyEditingRoomId) {
+    if (newRoomJson.id !== state.currentlyEditing.roomId) {
       changeIdOfCurrentRoomInPlace(state, newRoomJson.id);
     }
 
@@ -213,7 +214,7 @@ export const editRoomReducers = {
       const prevNcrRoom = rooms[prevOutboundNCR.with.room];
       if (
         prevNcrRoom.meta?.nonContiguousRelationship?.with.room ===
-        state.currentlyEditingRoomId
+        state.currentlyEditing.roomId
       ) {
         delete prevNcrRoom.meta.nonContiguousRelationship;
       }
@@ -293,13 +294,6 @@ export const editRoomReducers = {
       currentRoomJson[forwardDirection] &&
       selectRoomFromLevelEditorState(state, currentRoomJson[forwardDirection]);
 
-    // break the link the other way, if one exists:
-    if (
-      previouslyLinkedRoom?.[reverseProperty] === state.currentlyEditingRoomId
-    ) {
-      previouslyLinkedRoom[reverseProperty] = undefined;
-    }
-
     currentRoomJson[forwardDirection] = newLinkedToRoomId;
 
     const newlyLinkedToRoom =
@@ -307,24 +301,38 @@ export const editRoomReducers = {
       selectRoomFromLevelEditorState(state, newLinkedToRoomId);
 
     if (newlyLinkedToRoom !== undefined) {
-      // add the link back down, if there is a room to add it to:
       newlyLinkedToRoom[reverseProperty] = currentRoomJson.id;
+
+      if (payload.createNew && previouslyLinkedRoom) {
+        newlyLinkedToRoom[forwardDirection] = previouslyLinkedRoom.id;
+        previouslyLinkedRoom[reverseProperty] = newlyLinkedToRoom.id;
+      }
     }
 
-    // if creating a link, remove some floors:
+    if (!payload.createNew && previouslyLinkedRoom) {
+      if (
+        previouslyLinkedRoom[reverseProperty] === state.currentlyEditing.roomId
+      ) {
+        previouslyLinkedRoom[reverseProperty] = undefined;
+      }
+    }
+
     if (newlyLinkedToRoom) {
       changeFloorTypeInPlace(
         forwardDirection === "roomBelow" ? currentRoomJson : newlyLinkedToRoom,
         "none",
       );
     } else {
-      // broke a link - put floor back:
       changeFloorTypeInPlace(
         forwardDirection === "roomBelow" ? currentRoomJson : (
           previouslyLinkedRoom!
         ),
         "standable",
       );
+    }
+
+    if (payload.createNew && newLinkedToRoomId) {
+      changeCurrentRoomInPlace(state, newLinkedToRoomId as EditorRoomId);
     }
   },
 } satisfies SliceCaseReducers<LevelEditorState>;

--- a/src/editor/slice/reducers/insertRoomReducers.test.ts
+++ b/src/editor/slice/reducers/insertRoomReducers.test.ts
@@ -1,0 +1,632 @@
+import { produce } from "immer";
+import { describe, expect, test } from "vitest";
+
+import type {
+  EditorJsonItem,
+  EditorRoomId,
+  EditorRoomItemId,
+} from "../../editorTypes";
+
+import { exitGameRoomId } from "../../../model/json/ItemConfigMap";
+import { insertRoom, type LevelEditorState } from "../levelEditorSlice";
+import {
+  editorStateWithOneRoomWithNoItems,
+  reduceLevelEditorActions,
+  testRoomId,
+} from "./__test__/storeStates";
+
+type DoorItem = EditorJsonItem<"door">;
+
+const roomB = "roomB" as EditorRoomId;
+const door1 = "door1" as EditorRoomItemId;
+const door2 = "door2" as EditorRoomItemId;
+
+const stateWithFloor: LevelEditorState = produce(
+  editorStateWithOneRoomWithNoItems,
+  (draft) => {
+    draft.campaignInProgress.rooms[testRoomId].items[
+      "floor0" as EditorRoomItemId
+    ] = {
+      type: "floor",
+      config: {
+        floorType: "standable",
+        scenery: "blacktooth",
+        times: { x: 8, y: 8 },
+      },
+      position: { x: 0, y: 0, z: 0 },
+    };
+  },
+);
+
+const stateWithFloorAndRoomB: LevelEditorState = produce(
+  stateWithFloor,
+  (draft) => {
+    draft.campaignInProgress.rooms[roomB] = {
+      id: roomB,
+      planet: "blacktooth",
+      color: { hue: "cyan", shade: "basic" },
+      items: {
+        ["floor0" as EditorRoomItemId]: {
+          type: "floor",
+          config: {
+            floorType: "standable",
+            scenery: "blacktooth",
+            times: { x: 8, y: 8 },
+          },
+          position: { x: 0, y: 0, z: 0 },
+        },
+      },
+    };
+  },
+);
+
+describe("insertRoom with no existing doors", () => {
+  test("creates a new room in the campaign", () => {
+    const result = reduceLevelEditorActions(
+      stateWithFloor,
+      insertRoom({ direction: "left" }),
+    );
+
+    const roomIds = Object.keys(result.campaignInProgress.rooms);
+    expect(roomIds).toHaveLength(2);
+  });
+
+  test("adds a door in the given direction to the current room", () => {
+    const result = reduceLevelEditorActions(
+      stateWithFloor,
+      insertRoom({ direction: "left" }),
+    );
+
+    const currentRoomItems = Object.values(
+      result.campaignInProgress.rooms[testRoomId].items,
+    );
+    const doors = currentRoomItems.filter(
+      (item): item is EditorJsonItem<"door"> => item.type === "door",
+    );
+
+    expect(doors).toHaveLength(1);
+    expect(doors[0].config).toMatchObject({ direction: "left" });
+  });
+
+  test("the new door points to the newly created room", () => {
+    const result = reduceLevelEditorActions(
+      stateWithFloor,
+      insertRoom({ direction: "left" }),
+    );
+
+    const currentRoomItems = Object.values(
+      result.campaignInProgress.rooms[testRoomId].items,
+    );
+    const [door] = currentRoomItems.filter(
+      (item): item is EditorJsonItem<"door"> => item.type === "door",
+    );
+    const newRoomId = door.config.toRoom as EditorRoomId;
+
+    expect(result.campaignInProgress.rooms[newRoomId]).toBeDefined();
+  });
+
+  test("the new room has a return door pointing back", () => {
+    const result = reduceLevelEditorActions(
+      stateWithFloor,
+      insertRoom({ direction: "left" }),
+    );
+
+    const currentRoomItems = Object.values(
+      result.campaignInProgress.rooms[testRoomId].items,
+    );
+    const [door] = currentRoomItems.filter(
+      (item): item is EditorJsonItem<"door"> => item.type === "door",
+    );
+    const newRoomId = door.config.toRoom as EditorRoomId;
+    const newRoomItems = Object.values(
+      result.campaignInProgress.rooms[newRoomId].items,
+    );
+    const returnDoors = newRoomItems.filter(
+      (item): item is EditorJsonItem<"door"> =>
+        item.type === "door" && item.config.direction === "right",
+    );
+
+    expect(returnDoors).toHaveLength(1);
+    expect(returnDoors[0].config.toRoom).toBe(testRoomId);
+  });
+
+  test("doors are cross-linked with toDoor", () => {
+    const result = reduceLevelEditorActions(
+      stateWithFloor,
+      insertRoom({ direction: "left" }),
+    );
+
+    const currentRoom = result.campaignInProgress.rooms[testRoomId];
+    const currentRoomDoorEntries = Object.entries(currentRoom.items).filter(
+      ([, item]) => item.type === "door",
+    );
+    const [[outDoorId, outDoorRaw]] = currentRoomDoorEntries;
+    const outDoor = outDoorRaw as DoorItem;
+
+    const newRoomId = outDoor.config.toRoom as EditorRoomId;
+    const newRoom = result.campaignInProgress.rooms[newRoomId];
+    const returnDoor = newRoom.items[
+      outDoor.config.toDoor! as EditorRoomItemId
+    ] as DoorItem;
+
+    expect(returnDoor).toBeDefined();
+    expect(returnDoor.config.toDoor).toBe(outDoorId);
+  });
+
+  test("centres the door on an 8-unit wall with 3 units on each side", () => {
+    const result = reduceLevelEditorActions(
+      stateWithFloor,
+      insertRoom({ direction: "left" }),
+    );
+
+    const currentRoomItems = Object.values(
+      result.campaignInProgress.rooms[testRoomId].items,
+    );
+    const [door] = currentRoomItems.filter(
+      (item): item is EditorJsonItem<"door"> => item.type === "door",
+    );
+
+    expect(door.position).toEqual({ x: 8, y: 3, z: 0 });
+  });
+
+  test("navigates to the newly created room after insertion", () => {
+    const result = reduceLevelEditorActions(
+      stateWithFloor,
+      insertRoom({ direction: "away" }),
+    );
+
+    expect(result.currentlyEditing.roomId).not.toBe(testRoomId);
+    expect(
+      result.campaignInProgress.rooms[result.currentlyEditing.roomId],
+    ).toBeDefined();
+  });
+});
+
+describe("insertRoom with existing door in that direction", () => {
+  const stateWithDoorToB: LevelEditorState = produce(
+    stateWithFloorAndRoomB,
+    (draft) => {
+      draft.campaignInProgress.rooms[testRoomId].items[door1] = {
+        type: "door",
+        config: { toRoom: roomB, direction: "left" },
+        position: { x: 8, y: 4, z: 0 },
+      };
+      draft.campaignInProgress.rooms[roomB].items[door2] = {
+        type: "door",
+        config: { toRoom: testRoomId, direction: "right", toDoor: door1 },
+        position: { x: 0, y: 4, z: 0 },
+      };
+      (
+        draft.campaignInProgress.rooms[testRoomId].items[door1] as DoorItem
+      ).config.toDoor = door2;
+    },
+  );
+
+  test("re-points the current room door to the new room", () => {
+    const result = reduceLevelEditorActions(
+      stateWithDoorToB,
+      insertRoom({ direction: "left" }),
+    );
+
+    const currentDoor = result.campaignInProgress.rooms[testRoomId].items[
+      door1
+    ] as DoorItem;
+    expect(currentDoor.config.toRoom).not.toBe(roomB);
+
+    const newRoomId = currentDoor.config.toRoom as EditorRoomId;
+    expect(result.campaignInProgress.rooms[newRoomId]).toBeDefined();
+  });
+
+  test("re-points the inbound door from roomB to the new room", () => {
+    const result = reduceLevelEditorActions(
+      stateWithDoorToB,
+      insertRoom({ direction: "left" }),
+    );
+
+    const roomBDoor = result.campaignInProgress.rooms[roomB].items[
+      door2
+    ] as DoorItem;
+    expect(roomBDoor.config.toRoom).not.toBe(testRoomId);
+
+    const newRoomId = roomBDoor.config.toRoom as EditorRoomId;
+    expect(result.campaignInProgress.rooms[newRoomId]).toBeDefined();
+  });
+
+  test("the new room has a return door to the current room and a forward door to roomB", () => {
+    const result = reduceLevelEditorActions(
+      stateWithDoorToB,
+      insertRoom({ direction: "left" }),
+    );
+
+    const currentDoor = result.campaignInProgress.rooms[testRoomId].items[
+      door1
+    ] as DoorItem;
+    const newRoomId = currentDoor.config.toRoom as EditorRoomId;
+    const newRoomItems = Object.values(
+      result.campaignInProgress.rooms[newRoomId].items,
+    );
+    const newRoomDoors = newRoomItems.filter(
+      (item): item is EditorJsonItem<"door"> => item.type === "door",
+    );
+
+    const returnDoor = newRoomDoors.find(
+      (d) => d.config.toRoom === testRoomId && d.config.direction === "right",
+    );
+    const forwardDoor = newRoomDoors.find(
+      (d) => d.config.toRoom === roomB && d.config.direction === "left",
+    );
+
+    expect(returnDoor).toBeDefined();
+    expect(forwardDoor).toBeDefined();
+  });
+
+  test("toDoor cross-links are maintained through the new room", () => {
+    const result = reduceLevelEditorActions(
+      stateWithDoorToB,
+      insertRoom({ direction: "left" }),
+    );
+
+    const currentDoor = result.campaignInProgress.rooms[testRoomId].items[
+      door1
+    ] as DoorItem;
+    const newRoomId = currentDoor.config.toRoom as EditorRoomId;
+    const newRoom = result.campaignInProgress.rooms[newRoomId];
+
+    const returnDoorId = currentDoor.config.toDoor! as EditorRoomItemId;
+    const returnDoor = newRoom.items[returnDoorId] as DoorItem;
+    expect(returnDoor.config.toDoor).toBe(door1);
+
+    const roomBDoor = result.campaignInProgress.rooms[roomB].items[
+      door2
+    ] as DoorItem;
+    const forwardDoorId = roomBDoor.config.toDoor! as EditorRoomItemId;
+    const forwardDoor = newRoom.items[forwardDoorId] as DoorItem;
+    expect(forwardDoor.config.toDoor).toBe(door2);
+  });
+});
+
+describe("insertRoom with door to $$final", () => {
+  const stateWithFinalDoor: LevelEditorState = produce(
+    stateWithFloor,
+    (draft) => {
+      draft.campaignInProgress.rooms[testRoomId].items[door1] = {
+        type: "door",
+        config: { toRoom: exitGameRoomId, direction: "away" },
+        position: { x: 4, y: 8, z: 0 },
+      };
+    },
+  );
+
+  test("re-points the current room door to the new room", () => {
+    const result = reduceLevelEditorActions(
+      stateWithFinalDoor,
+      insertRoom({ direction: "away" }),
+    );
+
+    const currentDoor = result.campaignInProgress.rooms[testRoomId].items[
+      door1
+    ] as DoorItem;
+    expect(currentDoor.config.toRoom).not.toBe(exitGameRoomId);
+  });
+
+  test("the new room gets a door pointing to $$final", () => {
+    const result = reduceLevelEditorActions(
+      stateWithFinalDoor,
+      insertRoom({ direction: "away" }),
+    );
+
+    const currentDoor = result.campaignInProgress.rooms[testRoomId].items[
+      door1
+    ] as DoorItem;
+    const newRoomId = currentDoor.config.toRoom as EditorRoomId;
+    const newRoomItems = Object.values(
+      result.campaignInProgress.rooms[newRoomId].items,
+    );
+    const finalDoor = newRoomItems.find(
+      (item): item is EditorJsonItem<"door"> =>
+        item.type === "door" && item.config.toRoom === exitGameRoomId,
+    );
+
+    expect(finalDoor).toBeDefined();
+    expect(finalDoor!.config.direction).toBe("away");
+  });
+});
+
+describe("insertRoom with multiple doors in same direction", () => {
+  const stateWithTwoDoors: LevelEditorState = produce(
+    stateWithFloorAndRoomB,
+    (draft) => {
+      draft.campaignInProgress.rooms[testRoomId].items[door1] = {
+        type: "door",
+        config: { toRoom: roomB, direction: "towards" },
+        position: { x: 2, y: 0, z: 0 },
+      };
+      draft.campaignInProgress.rooms[testRoomId].items[door2] = {
+        type: "door",
+        config: { toRoom: roomB, direction: "towards" },
+        position: { x: 5, y: 0, z: 0 },
+      };
+    },
+  );
+
+  test("creates return doors for each outgoing door", () => {
+    const result = reduceLevelEditorActions(
+      stateWithTwoDoors,
+      insertRoom({ direction: "towards" }),
+    );
+
+    const d1 = result.campaignInProgress.rooms[testRoomId].items[
+      door1
+    ] as DoorItem;
+    const newRoomId = d1.config.toRoom as EditorRoomId;
+    const newRoomItems = Object.values(
+      result.campaignInProgress.rooms[newRoomId].items,
+    );
+    const returnDoors = newRoomItems.filter(
+      (item): item is EditorJsonItem<"door"> =>
+        item.type === "door" && item.config.toRoom === testRoomId,
+    );
+
+    expect(returnDoors).toHaveLength(2);
+  });
+});
+
+describe("insertRoom when unconnected room already exists at target grid position", () => {
+  const roomC = "roomC" as EditorRoomId;
+  const roomD = "roomD" as EditorRoomId;
+  const makeFloor = () =>
+    ({
+      type: "floor" as const,
+      config: {
+        floorType: "standable" as const,
+        scenery: "blacktooth" as const,
+        times: { x: 8, y: 8 },
+      },
+      position: { x: 0, y: 0, z: 0 },
+    }) as const;
+
+  const stateWithAdjacentUnconnectedRoom: LevelEditorState = produce(
+    stateWithFloorAndRoomB,
+    (draft) => {
+      draft.campaignInProgress.rooms[roomC] = {
+        id: roomC,
+        planet: "blacktooth",
+        color: { hue: "cyan", shade: "basic" },
+        items: { ["f" as EditorRoomItemId]: makeFloor() },
+      };
+      draft.campaignInProgress.rooms[roomD] = {
+        id: roomD,
+        planet: "blacktooth",
+        color: { hue: "cyan", shade: "basic" },
+        items: { ["f" as EditorRoomItemId]: makeFloor() },
+      };
+      draft.campaignInProgress.rooms[testRoomId].items[door1] = {
+        type: "door",
+        config: { toRoom: roomB, direction: "left" },
+        position: { x: 8, y: 3, z: 0 },
+      };
+      draft.campaignInProgress.rooms[roomB].items[door1] = {
+        type: "door",
+        config: { toRoom: testRoomId, direction: "right" },
+        position: { x: 0, y: 3, z: 0 },
+      };
+      draft.campaignInProgress.rooms[roomB].items[door2] = {
+        type: "door",
+        config: { toRoom: roomC, direction: "away" },
+        position: { x: 3, y: 8, z: 0 },
+      };
+      draft.campaignInProgress.rooms[roomC].items[door1] = {
+        type: "door",
+        config: { toRoom: roomB, direction: "towards" },
+        position: { x: 3, y: 0, z: 0 },
+      };
+      draft.campaignInProgress.rooms[roomC].items[door2] = {
+        type: "door",
+        config: { toRoom: roomD, direction: "right" },
+        position: { x: 0, y: 3, z: 0 },
+      };
+      draft.campaignInProgress.rooms[roomD].items[door1] = {
+        type: "door",
+        config: { toRoom: roomC, direction: "left" },
+        position: { x: 8, y: 3, z: 0 },
+      };
+    },
+  );
+
+  test("connects to the existing room instead of creating a new one", () => {
+    const before = Object.keys(
+      stateWithAdjacentUnconnectedRoom.campaignInProgress.rooms,
+    ).length;
+
+    const result = reduceLevelEditorActions(
+      stateWithAdjacentUnconnectedRoom,
+      insertRoom({ direction: "away" }),
+    );
+
+    const after = Object.keys(result.campaignInProgress.rooms).length;
+    expect(after).toBe(before);
+
+    const currentRoomDoors = Object.values(
+      result.campaignInProgress.rooms[testRoomId].items,
+    ).filter((item): item is EditorJsonItem<"door"> => item.type === "door");
+    const doorToD = currentRoomDoors.find((d) => d.config.toRoom === roomD);
+    expect(doorToD).toBeDefined();
+    expect(doorToD!.config.direction).toBe("away");
+  });
+
+  test("navigates to the existing room after connecting", () => {
+    const result = reduceLevelEditorActions(
+      stateWithAdjacentUnconnectedRoom,
+      insertRoom({ direction: "away" }),
+    );
+
+    expect(result.currentlyEditing.roomId).toBe(roomD);
+  });
+});
+
+describe("insertRoom from a subroom of a multi-chunk room", () => {
+  const stateWithTwoChunkRoom: LevelEditorState = produce(
+    editorStateWithOneRoomWithNoItems,
+    (draft) => {
+      draft.campaignInProgress.rooms[testRoomId] = {
+        id: testRoomId,
+        planet: "blacktooth",
+        color: { hue: "cyan", shade: "basic" },
+        items: {
+          ["floor" as EditorRoomItemId]: {
+            type: "floor",
+            config: {
+              floorType: "standable",
+              scenery: "blacktooth",
+              times: { x: 16, y: 8 },
+            },
+            position: { x: 0, y: 0, z: 0 },
+          },
+        },
+        meta: {
+          subRooms: {
+            "0": {
+              gridPosition: { x: 0, y: 0 },
+              physicalPosition: { from: { x: 0, y: 0 }, to: { x: 7, y: 7 } },
+            },
+            "1": {
+              gridPosition: { x: 1, y: 0 },
+              physicalPosition: {
+                from: { x: 8, y: 0 },
+                to: { x: 15, y: 7 },
+              },
+            },
+          },
+        },
+      };
+      draft.currentlyEditing = { roomId: testRoomId, subRoomId: "0" };
+    },
+  );
+
+  test("door is centred on the subroom, not the whole room", () => {
+    const result = reduceLevelEditorActions(
+      stateWithTwoChunkRoom,
+      insertRoom({ direction: "away" }),
+    );
+
+    const doors = Object.values(
+      result.campaignInProgress.rooms[testRoomId].items,
+    ).filter((item): item is EditorJsonItem<"door"> => item.type === "door");
+
+    expect(doors).toHaveLength(1);
+    expect(doors[0].position.x).toBe(3);
+    expect(doors[0].position.y).toBe(8);
+  });
+
+  test("inserting from subroom 1 centres the door on subroom 1", () => {
+    const stateOnSubRoom1 = produce(stateWithTwoChunkRoom, (draft) => {
+      draft.currentlyEditing = { roomId: testRoomId, subRoomId: "1" };
+    });
+
+    const result = reduceLevelEditorActions(
+      stateOnSubRoom1,
+      insertRoom({ direction: "away" }),
+    );
+
+    const doors = Object.values(
+      result.campaignInProgress.rooms[testRoomId].items,
+    ).filter((item): item is EditorJsonItem<"door"> => item.type === "door");
+
+    expect(doors).toHaveLength(1);
+    expect(doors[0].position.x).toBe(11);
+    expect(doors[0].position.y).toBe(8);
+  });
+});
+
+describe("insertRoom from a subroom where floor extends beyond subroom bounds", () => {
+  const stateWithIrregularChunks: LevelEditorState = produce(
+    editorStateWithOneRoomWithNoItems,
+    (draft) => {
+      draft.campaignInProgress.rooms[testRoomId] = {
+        id: testRoomId,
+        planet: "blacktooth",
+        color: { hue: "cyan", shade: "basic" },
+        items: {
+          ["floor" as EditorRoomItemId]: {
+            type: "floor",
+            config: {
+              floorType: "standable",
+              scenery: "blacktooth",
+              times: { x: 17, y: 8 },
+            },
+            position: { x: 0, y: 4, z: 0 },
+          },
+        },
+        meta: {
+          subRooms: {
+            left: {
+              gridPosition: { x: 1, y: 0 },
+              physicalPosition: {
+                from: { x: 10, y: 4 },
+                to: { x: 17, y: 12 },
+              },
+            },
+            right: {
+              gridPosition: { x: 0, y: 0 },
+              physicalPosition: {
+                from: { x: 0, y: 4 },
+                to: { x: 10, y: 12 },
+              },
+            },
+          },
+        },
+      };
+      draft.currentlyEditing = { roomId: testRoomId, subRoomId: "left" };
+    },
+  );
+
+  test("door is placed at the room wall edge, not at subroom boundary", () => {
+    const result = reduceLevelEditorActions(
+      stateWithIrregularChunks,
+      insertRoom({ direction: "away" }),
+    );
+
+    const doors = Object.values(
+      result.campaignInProgress.rooms[testRoomId].items,
+    ).filter((item): item is EditorJsonItem<"door"> => item.type === "door");
+
+    expect(doors).toHaveLength(1);
+    expect(doors[0].position.y).toBe(12);
+  });
+
+  test("door is centred within the subroom x range", () => {
+    const result = reduceLevelEditorActions(
+      stateWithIrregularChunks,
+      insertRoom({ direction: "away" }),
+    );
+
+    const doors = Object.values(
+      result.campaignInProgress.rooms[testRoomId].items,
+    ).filter((item): item is EditorJsonItem<"door"> => item.type === "door");
+
+    expect(doors).toHaveLength(1);
+    expect(doors[0].position.x).toBe(12);
+  });
+
+  test("the new room has a return door", () => {
+    const result = reduceLevelEditorActions(
+      stateWithIrregularChunks,
+      insertRoom({ direction: "away" }),
+    );
+
+    const doors = Object.values(
+      result.campaignInProgress.rooms[testRoomId].items,
+    ).filter((item): item is EditorJsonItem<"door"> => item.type === "door");
+
+    const newRoomId = doors[0].config.toRoom as EditorRoomId;
+    const newRoom = result.campaignInProgress.rooms[newRoomId];
+    const returnDoors = Object.values(newRoom.items).filter(
+      (item): item is EditorJsonItem<"door"> =>
+        item.type === "door" && item.config.direction === "towards",
+    );
+
+    expect(returnDoors).toHaveLength(1);
+    expect(returnDoors[0].config.toRoom).toBe(testRoomId);
+    expect(returnDoors[0].position.x).toBe(2);
+  });
+});

--- a/src/editor/slice/reducers/saveAndLoadReducers.ts
+++ b/src/editor/slice/reducers/saveAndLoadReducers.ts
@@ -6,6 +6,7 @@ import { first } from "../../../utils/iterators/first";
 import { pick } from "../../../utils/pick";
 import { type EditorCampaign } from "../../editorTypes";
 import { initialLevelEditorSliceState } from "../initialLevelEditorSliceState";
+import { changeCurrentRoomInPlace } from "../inPlaceMutators/changeCurrentRoomInPlace";
 import { type LevelEditorState } from "../levelEditorSlice";
 import { levelEditorSliceNonPersistedFields } from "../levelEditorSliceTransientFields";
 
@@ -51,7 +52,7 @@ export const saveAndLoadReducers = {
     if (startingRoom === undefined) {
       throw new Error("could not find any rooms in this campaign");
     }
-    state.currentlyEditingRoomId = startingRoom;
+    changeCurrentRoomInPlace(state, startingRoom, undefined, true);
   },
 
   setRemoteCampaign(

--- a/src/editor/slice/reducers/undoReducers.ts
+++ b/src/editor/slice/reducers/undoReducers.ts
@@ -33,7 +33,7 @@ export const undoReducers = {
     const {
       campaignInProgress,
       history: { undo, redo },
-      currentlyEditingRoomId,
+      currentlyEditing: { roomId: currentlyEditingRoomId },
     } = state;
 
     if (undo.length === 0) {
@@ -61,7 +61,7 @@ export const undoReducers = {
     const {
       campaignInProgress,
       history: { redo, undo },
-      currentlyEditingRoomId,
+      currentlyEditing: { roomId: currentlyEditingRoomId },
     } = state;
 
     if (redo.length === 0) {

--- a/src/editor/slice/roomJsonSelectors.ts
+++ b/src/editor/slice/roomJsonSelectors.ts
@@ -1,0 +1,39 @@
+import type { EditorRoomJson } from "../editorTypes";
+
+import { iterateRoomJsonItemsWithIds } from "../../model/RoomJson";
+
+export const roomFloorMinY = (roomJson: EditorRoomJson): number =>
+  iterateRoomJsonItemsWithIds(roomJson.items, "floor").reduce(
+    (min, [, item]) => {
+      const itemTop = item.position.y;
+      return Math.min(min, itemTop);
+    },
+    Number.POSITIVE_INFINITY,
+  );
+
+export const roomFloorMaxY = (roomJson: EditorRoomJson): number =>
+  iterateRoomJsonItemsWithIds(roomJson.items, "floor").reduce(
+    (max, [, item]) => {
+      const itemBottom = item.position.y + item.config.times.y;
+      return Math.max(max, itemBottom);
+    },
+    Number.NEGATIVE_INFINITY,
+  );
+
+export const roomFloorMinX = (roomJson: EditorRoomJson): number =>
+  iterateRoomJsonItemsWithIds(roomJson.items, "floor").reduce(
+    (min, [, item]) => {
+      const itemTop = item.position.x;
+      return Math.min(min, itemTop);
+    },
+    Number.POSITIVE_INFINITY,
+  );
+
+export const roomFloorMaxX = (roomJson: EditorRoomJson): number =>
+  iterateRoomJsonItemsWithIds(roomJson.items, "floor").reduce(
+    (max, [, item]) => {
+      const itemBottom = item.position.x + item.config.times.x;
+      return Math.max(max, itemBottom);
+    },
+    Number.NEGATIVE_INFINITY,
+  );

--- a/src/editor/toolbar/LevelEditorToolbar.tsx
+++ b/src/editor/toolbar/LevelEditorToolbar.tsx
@@ -42,7 +42,7 @@ export const LevelEditorToolbar = () => {
     (state) => state.levelEditor.campaignInProgress,
   );
   const currentlyEditingRoomId = useEditorAppSelector(
-    (state) => state.levelEditor.currentlyEditingRoomId,
+    (state) => state.levelEditor.currentlyEditing.roomId,
   );
   const dispatch = useAppDispatch();
   const campaignName = useEditorAppSelector(
@@ -59,7 +59,7 @@ export const LevelEditorToolbar = () => {
           <BitmapText className="">Campaign</BitmapText>
           {campaignName ?
             <BitmapText className="text-highlightBeige">
-              {`'${campaignName}'`}
+              {`‘${campaignName}’`}
             </BitmapText>
           : <BitmapText className="text-midRed">{`(untitled)`}</BitmapText>}
         </div>

--- a/src/editor/toolbar/buttons/PlayTestButton.tsx
+++ b/src/editor/toolbar/buttons/PlayTestButton.tsx
@@ -34,7 +34,7 @@ export const PlayTestButton = () => {
               searchParams.set("playAsHeels", "1");
             }
             if (!fromStart) {
-              url.hash = state.levelEditor.currentlyEditingRoomId;
+              url.hash = state.levelEditor.currentlyEditing.roomId;
             }
             window.open(url.toString(), "playtest");
           }}

--- a/src/editor/toolbar/buttons/RoomsAboveOrBelow.tsx
+++ b/src/editor/toolbar/buttons/RoomsAboveOrBelow.tsx
@@ -21,7 +21,7 @@ const RoomsAboveOrBelowSelectOrCreate = ({
     ({ levelEditor }) => levelEditor.campaignInProgress,
   );
   const currentlyEditingRoomId = useEditorAppSelector(
-    ({ levelEditor }) => levelEditor.currentlyEditingRoomId,
+    ({ levelEditor }) => levelEditor.currentlyEditing.roomId,
   );
   const dispatch = useAppDispatch();
 

--- a/src/editor/toolbar/buttons/ToolbarButton.tsx
+++ b/src/editor/toolbar/buttons/ToolbarButton.tsx
@@ -1,7 +1,8 @@
-import { type PropsWithChildren, type ReactNode } from "react";
+import type { PropsWithChildren, ReactNode, Ref } from "react";
+
+import type { ShortcutKeys } from "../../../ui/useKeyboardShortcut";
 
 import { Button } from "../../../ui/Button";
-import { type ShortcutKeys } from "../../../ui/useKeyboardShortcut";
 import {
   buttonSizeClassNames,
   buttonSmallSizeClassNames,
@@ -15,6 +16,7 @@ export type ToolbarButtonProps = {
   shortcutKeys?: ShortcutKeys;
   small?: boolean;
   tooltipContent?: ReactNode;
+  ref?: Ref<HTMLButtonElement>;
 };
 
 export const ToolbarButton = ({
@@ -26,9 +28,11 @@ export const ToolbarButton = ({
   shortcutKeys,
   small = false,
   tooltipContent,
+  ref,
 }: PropsWithChildren<ToolbarButtonProps>) => {
   return (
     <Button
+      ref={ref}
       disabled={disabled}
       selected={isCurrentTool}
       className={`

--- a/src/game/components/dialogs/menuDialog/dialogs/map/LazyMapRoomTooltipDecorator.ts
+++ b/src/game/components/dialogs/menuDialog/dialogs/map/LazyMapRoomTooltipDecorator.ts
@@ -1,0 +1,12 @@
+import { lazy } from "react";
+
+import type { WrapClickableRoomDecoratorComponent } from "./RoomDecoratorProps";
+
+import { importOnce } from "../../../../../../utils/importOnce";
+
+const importMapRoomTooltipDecorator = importOnce(
+  () => import("./MapRoomTooltipDecorator"),
+);
+
+export const LazyMapRoomTooltipDecorator: WrapClickableRoomDecoratorComponent<string> =
+  lazy(importMapRoomTooltipDecorator);

--- a/src/game/components/dialogs/menuDialog/dialogs/map/Map.svg.tsx
+++ b/src/game/components/dialogs/menuDialog/dialogs/map/Map.svg.tsx
@@ -1,28 +1,35 @@
-import { type ValueOf } from "type-fest";
+import type { ValueOf } from "type-fest";
 
-import {
-  type CharacterName,
-  type IndividualCharacterName,
+import { Suspense } from "react";
+
+import type {
+  CharacterName,
+  IndividualCharacterName,
 } from "../../../../../../model/modelTypes";
+import type { CharacterRooms } from "../../../../../gameState/GameState";
+import type { PlayableItem } from "../../../../../physics/itemPredicates";
+import type { MapData } from "./MapData";
+import type {
+  PostfixRoomDecoratorComponent,
+  WrapClickableRoomDecoratorComponent,
+} from "./RoomDecoratorProps";
+
 import { getRoomItem } from "../../../../../../model/RoomState";
 import { emptyObject } from "../../../../../../utils/empty";
-import { type CharacterRooms } from "../../../../../gameState/GameState";
-import { type PlayableItem } from "../../../../../physics/itemPredicates";
 import { findSubRoomForItem } from "./itemIsInSubRoom";
 import { MapBackground } from "./MapBackground";
 import { mapSvgMarginX, mapSvgMarginY } from "./mapConstants";
-import { type MapData } from "./MapData";
 import { RoomSvg } from "./Room.svg";
 import { roomWorldPosition } from "./roomWorldPosition";
 import { ScrollIntoView } from "./ScrollIntoView";
 import { translateXyz } from "./svgHelpers";
 
-export type OnRoomClick<RoomId extends string> = (roomId: RoomId) => void;
-
 export type MapSvgProps<RoomId extends string> = MapData<RoomId> & {
   containerWidth?: number;
   onPlayableClick?: (name: IndividualCharacterName) => void;
-  onRoomClick?: OnRoomClick<RoomId>;
+  /** outermost first — the last decorator in the array wraps the clickable path directly */
+  clickableAreaDecorators?: WrapClickableRoomDecoratorComponent<RoomId>[];
+  postfixDecorators?: PostfixRoomDecoratorComponent<RoomId>[];
 };
 
 export type Bounds = {
@@ -72,7 +79,9 @@ export const MapSvg = <RoomId extends string>(props: MapSvgProps<RoomId>) => {
     roomsExplored,
     onPlayableClick,
     curRoomId,
-    onRoomClick,
+    curSubRoomId,
+    clickableAreaDecorators,
+    postfixDecorators,
   } = props;
 
   if (containerWidth === undefined) {
@@ -112,6 +121,8 @@ export const MapSvg = <RoomId extends string>(props: MapSvgProps<RoomId>) => {
         {orderedPositions.map((gridPositionSpec) => {
           const { roomId, subRoomId, gridPosition } = gridPositionSpec;
           const roomRenderingId = `${roomId}/${subRoomId}`;
+          const isCurrentRoom = curRoomId === roomId;
+          const isCurrentSubRoom = isCurrentRoom && curSubRoomId === subRoomId;
 
           return (
             <g
@@ -123,7 +134,7 @@ export const MapSvg = <RoomId extends string>(props: MapSvgProps<RoomId>) => {
                 roomGridPositionSpec={gridPositionSpec}
                 roomPickupsCollected={pickupsCollected[roomId] ?? emptyObject}
                 roomJson={campaign.rooms[roomId]}
-                isCurrentRoom={curRoomId === roomId}
+                isCurrentRoom={isCurrentRoom}
                 headItemInRoom={selectPlayableItemInRoomAndSubroom(
                   characterRooms,
                   "head",
@@ -145,15 +156,67 @@ export const MapSvg = <RoomId extends string>(props: MapSvgProps<RoomId>) => {
                 currentCharacterName={currentCharacterName}
                 roomVisited={roomsExplored[roomId] ?? false}
                 onPlayableClick={onPlayableClick}
-                onRoomClick={onRoomClick}
+                ClickableAreaWrapper={
+                  clickableAreaDecorators?.length ?
+                    ({ children }) =>
+                      clickableAreaDecorators.reduceRight(
+                        (wrapped, ClickableAreaDecorator) => (
+                          <Suspense fallback={null}>
+                            <ClickableAreaDecorator
+                              roomId={roomId}
+                              subRoomId={subRoomId}
+                              boundaries={gridPositionSpec.boundaries}
+                              isCurrentRoom={isCurrentRoom}
+                              isCurrentSubRoom={isCurrentSubRoom}
+                              allGridPositions={gridPositions}
+                            >
+                              {wrapped}
+                            </ClickableAreaDecorator>
+                          </Suspense>
+                        ),
+                        children,
+                      )
+                  : undefined
+                }
               />
-              {curRoomId === roomId ?
+              {isCurrentRoom ?
                 <ScrollIntoView svg smooth />
               : null}
             </g>
           );
         })}
       </g>
+      {postfixDecorators?.map((PostFixDecorator, decoratorIndex) => (
+        <g
+          key={decoratorIndex}
+          transform={`translate(${-mapBounds.l + mapSvgMarginX + (containerWidth - contentW) / 2},${-mapBounds.t + +mapSvgMarginY})`}
+        >
+          {orderedPositions.map((gridPositionSpec) => {
+            const { roomId, subRoomId, gridPosition, boundaries } =
+              gridPositionSpec;
+
+            return (
+              <g
+                key={`${roomId}/${subRoomId}`}
+                transform={translateXyz(roomWorldPosition(gridPosition))}
+              >
+                <Suspense fallback={null}>
+                  <PostFixDecorator
+                    roomId={roomId}
+                    subRoomId={subRoomId}
+                    boundaries={boundaries}
+                    isCurrentRoom={curRoomId === roomId}
+                    isCurrentSubRoom={
+                      curRoomId === roomId && curSubRoomId === subRoomId
+                    }
+                    allGridPositions={gridPositions}
+                  />
+                </Suspense>
+              </g>
+            );
+          })}
+        </g>
+      ))}
     </svg>
   );
 };

--- a/src/game/components/dialogs/menuDialog/dialogs/map/MapData.tsx
+++ b/src/game/components/dialogs/menuDialog/dialogs/map/MapData.tsx
@@ -26,6 +26,7 @@ export type MapData<RoomId extends string> = {
   characterRooms: CharacterRooms<RoomId>;
   currentCharacterName: CharacterName;
   curRoomId: RoomId | undefined;
+  curSubRoomId: string | undefined;
   gridPositions: SortedObjectOfRoomGridPositionSpecs<RoomId>;
   mapBounds: Bounds;
   pickupsCollected: PickupsCollected<RoomId>;

--- a/src/game/components/dialogs/menuDialog/dialogs/map/MapDialog.tsx
+++ b/src/game/components/dialogs/menuDialog/dialogs/map/MapDialog.tsx
@@ -9,29 +9,37 @@ import { useElementSize } from "../../../../../../utils/react/useElementSize";
 import { swopPlayables } from "../../../../../gameState/mutators/swopPlayables";
 import { useGameApi } from "../../../../GameApiContext";
 import { useScrollingFromInput } from "../useScrollingFromInput";
-import { MapSvg, type OnRoomClick } from "./Map.svg";
+import { createClickableRoomDecorator } from "./createClickableRoomDecorator";
+import { LazyMapRoomTooltipDecorator } from "./LazyMapRoomTooltipDecorator";
+import { MapSvg } from "./Map.svg";
 import { getMapColoursClass } from "./mapColours";
 import { useMapDataForCurrentGame } from "./useMapDataForCurrentGame";
 import { useAllowCharacterSwopping } from "./useTickingCurrentCharacterName";
+
+const useGameMapClickableAreaDecorators = <RoomId extends string>() => {
+  const cheatsOn = useCheatsOn();
+  const gameApi = useGameApi<RoomId>();
+
+  return useMemo(() => {
+    if (!cheatsOn) {
+      return undefined;
+    }
+
+    const clickableDecorator = createClickableRoomDecorator((roomId) => {
+      gameApi.changeRoom(roomId as RoomId);
+    });
+
+    return [LazyMapRoomTooltipDecorator, clickableDecorator];
+  }, [cheatsOn, gameApi]);
+};
 
 const MapDialog = <RoomId extends string>() => {
   const { ref: mapContainerRef, width: mapContainerWidth } =
     useElementSize<HTMLDialogElement>();
   const scrollingContentRef = useScrollingFromInput();
 
-  const cheatsOn = useCheatsOn();
-
   const gameApi = useGameApi<RoomId>();
 
-  const handleRoomClick = useMemo<OnRoomClick<RoomId> | undefined>(() => {
-    if (cheatsOn) {
-      return (roomId: RoomId) => {
-        gameApi.changeRoom(roomId);
-      };
-    }
-  }, [cheatsOn, gameApi]);
-
-  // the user can switch characters while looking at the map:
   useAllowCharacterSwopping();
 
   const mapData = useMapDataForCurrentGame<RoomId>();
@@ -41,7 +49,7 @@ const MapDialog = <RoomId extends string>() => {
     <MapSvg<RoomId>
       onPlayableClick={(name) => swopPlayables(gameApi.gameState, name)}
       containerWidth={mapContainerWidth}
-      onRoomClick={handleRoomClick}
+      clickableAreaDecorators={useGameMapClickableAreaDecorators<RoomId>()}
       {...mapData}
     />
   );

--- a/src/game/components/dialogs/menuDialog/dialogs/map/MapRoomTooltipDecorator.tsx
+++ b/src/game/components/dialogs/menuDialog/dialogs/map/MapRoomTooltipDecorator.tsx
@@ -1,0 +1,22 @@
+import { Suspense } from "react";
+
+import { LazyTooltip } from "../../../../../../ui/LazyTooltip";
+import { BitmapText } from "../../../../tailwindSprites/BitmapText";
+import { type WrapClickableRoomDecoratorComponentProps } from "./RoomDecoratorProps";
+
+const MapRoomTooltipDecorator = ({
+  roomId,
+  isCurrentRoom,
+  children,
+}: WrapClickableRoomDecoratorComponentProps<string>) => (
+  <Suspense fallback={children}>
+    <LazyTooltip
+      triggerContent={children}
+      tooltipContent={<BitmapText>{roomId}</BitmapText>}
+      tooltipOffset={isCurrentRoom ? 32 : 0}
+      tooltipPlacement="bottom"
+    />
+  </Suspense>
+);
+
+export default MapRoomTooltipDecorator;

--- a/src/game/components/dialogs/menuDialog/dialogs/map/Room.svg.tsx
+++ b/src/game/components/dialogs/menuDialog/dialogs/map/Room.svg.tsx
@@ -1,19 +1,21 @@
-import { type ReactNode, Suspense } from "react";
+import type { FunctionComponent, ReactElement } from "react";
 
-import {
-  type CharacterName,
-  type IndividualCharacterName,
+import type {
+  CharacterName,
+  IndividualCharacterName,
 } from "../../../../../../model/modelTypes";
-import { type RoomJson } from "../../../../../../model/RoomJson";
+import type { RoomJson } from "../../../../../../model/RoomJson";
+import type { RoomPickupsCollected } from "../../../../../gameState/GameState";
+import type { PlayableItem } from "../../../../../physics/itemPredicates";
+import type { Boundaries, RoomGridPositionSpec } from "./roomGridPositions";
+
 import { hudLowercaseCharTextureSize } from "../../../../../../sprites/spritesheet/spritesheetData/textureSizes";
-import { LazyTooltip } from "../../../../../../ui/LazyTooltip";
 import { valuesIter } from "../../../../../../utils/entries";
 import { range } from "../../../../../../utils/iterators/range";
 import { addXy, lengthXy } from "../../../../../../utils/vectors/vectors";
-import { type RoomPickupsCollected } from "../../../../../gameState/GameState";
-import { type PlayableItem } from "../../../../../physics/itemPredicates";
 import { projectWorldXyzToScreenXy } from "../../../../../render/projections";
 import { BitmapText } from "../../../../tailwindSprites/BitmapText";
+import { floorFillPathD } from "./floorFillPathD";
 import {
   InPlayItemsInRoomLayout,
   NotableJsonItemsInRoomLayout,
@@ -27,42 +29,10 @@ import {
   roomGridSizeZ,
 } from "./mapConstants";
 import { PlayableItemInRoom } from "./NotableItem";
-import {
-  type Boundaries,
-  type RoomGridPositionSpec,
-} from "./roomGridPositions";
 import { roomWorldPosition } from "./roomWorldPosition";
 import { project, roundForSvg, translateXyz } from "./svgHelpers";
 import { useNotableItems } from "./useNotableItems";
 import { VisitedFootprint } from "./VisitedFootprint";
-
-const FloorInteractiveArea = <RoomId extends string>({
-  onRoomClick,
-  roomId,
-  tooltipContent,
-}: {
-  onRoomClick: (roomId: RoomId) => void;
-  roomId: RoomId;
-  tooltipContent: ReactNode;
-}) => {
-  const clickablePath = (
-    <path
-      className="fill-transparent cursor-pointer"
-      d={floorFillPathD}
-      onClick={() => {
-        onRoomClick(roomId);
-      }}
-    />
-  );
-  return (
-    <Suspense fallback={clickablePath}>
-      <LazyTooltip
-        triggerContent={clickablePath}
-        tooltipContent={tooltipContent}
-      />
-    </Suspense>
-  );
-};
 
 const strokeWidth = 3;
 
@@ -75,13 +45,6 @@ const boundaryDashArrays = {
   open: "0,999",
   doorway: `${roundForSvg(boundaryLineLength * ((1 - doorwayGap) / 2) - strokeWidth / 2)}, ${roundForSvg(boundaryLineLength * doorwayGap + strokeWidth)}, 999`,
 };
-
-const floorFillPathD = `
-M ${project({})}
-L ${project({ y: roomGridSizeXY })}
-L ${project({ x: roomGridSizeXY, y: roomGridSizeXY })}
-L ${project({ x: roomGridSizeXY })}
-z`;
 
 const floorPathFillPathD = (
   boundaries: Boundaries,
@@ -179,9 +142,11 @@ type RoomSvgProps<RoomId extends string> = {
   headOverHeelsItemInRoom?: PlayableItem<"headOverHeels", RoomId>;
   roomPickupsCollected: RoomPickupsCollected;
   onPlayableClick?: (name: IndividualCharacterName) => void;
-  onRoomClick?: (roomId: RoomId) => void;
   currentCharacterName: CharacterName;
   isCurrentRoom: boolean;
+  ClickableAreaWrapper?: FunctionComponent<{
+    children: ReactElement;
+  }>;
 };
 
 export const RoomSvg = <RoomId extends string>({
@@ -194,12 +159,11 @@ export const RoomSvg = <RoomId extends string>({
   headOverHeelsItemInRoom,
   currentCharacterName,
   onPlayableClick,
-  onRoomClick,
   isCurrentRoom,
+  ClickableAreaWrapper,
 }: RoomSvgProps<RoomId>) => {
   const { id, roomAbove, color, items } = roomJson;
   const label = roomJson.meta?.label;
-  const highlightOnHover = onRoomClick !== undefined;
 
   // find some notable items:
   const notableItems = useNotableItems(
@@ -221,18 +185,16 @@ export const RoomSvg = <RoomId extends string>({
       data-room-id={id}
       strokeWidth={strokeWidth}
       className={`
-        ${roomAccentColourClass(color)} 
+        ${roomAccentColourClass(color)}
         ${
           isCurrentRoom ?
-            // make the current room look visually distinct by changing the floor colour:
             `[--floorColor:theme(colors.shadow)] zx:[--floorColor:theme(colors.zxBlack)] toppy:[--floorColor:theme(colors.toppyGrey3)]`
           : `[--floorColor:theme(colors.white)]`
-        } 
+        }
         ${
-          highlightOnHover ?
-            `
-            group/room
-            hover:[--roomHintColor:theme(colors.midRed)] 
+          ClickableAreaWrapper ?
+            `group/room
+            hover:[--roomHintColor:theme(colors.midRed)]
             zx:hover:[--roomHintColor:theme(colors.zxRed)]
             toppy:hover:[--roomHintColor:theme(colors.toppyPink2)]`
           : ""
@@ -262,9 +224,8 @@ export const RoomSvg = <RoomId extends string>({
           <path
             className={`fill-[var(--floorColor)]
               ${
-                highlightOnHover && !isCurrentRoom ?
-                  `
-                  group-hover/room:fill-pastelBlue
+                !isCurrentRoom ?
+                  `group-hover/room:fill-pastelBlue
                   zx:group-hover/room:fill-zxCyan
                   toppy:group-hover/room:fill-toppyCool1`
                 : ""
@@ -464,15 +425,15 @@ z
           </foreignObject>
         </g>
       )}
-      {onRoomClick ?
-        // add a transparent area over the whole floor if we need to handle clicks.
-        // otherwise, the rendering above is too complex to handle this
-        <FloorInteractiveArea
-          onRoomClick={onRoomClick}
-          roomId={id}
-          tooltipContent={<BitmapText>{roomJson.id}</BitmapText>}
-        />
-      : null}
+      {ClickableAreaWrapper && (
+        <ClickableAreaWrapper>
+          <path
+            className="fill-transparent cursor-pointer outline-none"
+            d={floorFillPathD}
+            tabIndex={-1}
+          />
+        </ClickableAreaWrapper>
+      )}
     </g>
   );
 };

--- a/src/game/components/dialogs/menuDialog/dialogs/map/RoomDecoratorProps.ts
+++ b/src/game/components/dialogs/menuDialog/dialogs/map/RoomDecoratorProps.ts
@@ -1,0 +1,24 @@
+import type { FunctionComponent, ReactElement } from "react";
+
+import type { Boundaries } from "./roomGridPositions";
+import type { SortedObjectOfRoomGridPositionSpecs } from "./sortRoomGridPositions";
+
+export type RoomDecoratorProps<RoomId extends string> = {
+  roomId: RoomId;
+  subRoomId: string;
+  boundaries: Boundaries;
+  isCurrentRoom: boolean;
+  isCurrentSubRoom: boolean;
+  allGridPositions: SortedObjectOfRoomGridPositionSpecs<RoomId>;
+};
+
+export type WrapClickableRoomDecoratorComponentProps<RoomId extends string> =
+  RoomDecoratorProps<RoomId> & {
+    children: ReactElement;
+  };
+
+export type PostfixRoomDecoratorComponent<RoomId extends string> =
+  FunctionComponent<RoomDecoratorProps<RoomId>>;
+
+export type WrapClickableRoomDecoratorComponent<RoomId extends string> =
+  FunctionComponent<WrapClickableRoomDecoratorComponentProps<RoomId>>;

--- a/src/game/components/dialogs/menuDialog/dialogs/map/createClickableRoomDecorator.tsx
+++ b/src/game/components/dialogs/menuDialog/dialogs/map/createClickableRoomDecorator.tsx
@@ -1,0 +1,22 @@
+import { cloneElement, type ReactElement } from "react";
+
+import type {
+  RoomDecoratorProps,
+  WrapClickableRoomDecoratorComponent,
+} from "./RoomDecoratorProps";
+
+export const createClickableRoomDecorator = <RoomId extends string>(
+  onClick: (roomId: RoomId, subRoomId: string) => void,
+): WrapClickableRoomDecoratorComponent<RoomId> => {
+  const ClickableRoomDecorator = ({
+    roomId,
+    subRoomId,
+    children,
+  }: RoomDecoratorProps<RoomId> & { children: ReactElement }) =>
+    cloneElement(children as ReactElement<Record<string, unknown>>, {
+      "data-room-click": `${roomId}/${subRoomId}`,
+      onClick: () => onClick(roomId, subRoomId),
+    });
+
+  return ClickableRoomDecorator;
+};

--- a/src/game/components/dialogs/menuDialog/dialogs/map/floorFillPathD.ts
+++ b/src/game/components/dialogs/menuDialog/dialogs/map/floorFillPathD.ts
@@ -1,0 +1,9 @@
+import { roomGridSizeXY } from "./mapConstants";
+import { project } from "./svgHelpers";
+
+export const floorFillPathD = `
+M ${project({})}
+L ${project({ y: roomGridSizeXY })}
+L ${project({ x: roomGridSizeXY, y: roomGridSizeXY })}
+L ${project({ x: roomGridSizeXY })}
+z`;

--- a/src/game/components/dialogs/menuDialog/dialogs/map/useMapDataForCurrentGame.tsx
+++ b/src/game/components/dialogs/menuDialog/dialogs/map/useMapDataForCurrentGame.tsx
@@ -71,6 +71,7 @@ export const useMapDataForCurrentGame = <
       return {
         mapBounds: findMapBounds(positions),
         curRoomId: curRoom?.roomJson.id,
+        curSubRoomId: undefined,
         gridPositions: sortedObjectOfPositions,
         currentCharacterName,
         pickupsCollected: gameState.pickupsCollected,

--- a/src/ui/Tooltip.tsx
+++ b/src/ui/Tooltip.tsx
@@ -3,6 +3,7 @@ import {
   flip,
   FloatingPortal,
   offset,
+  type Placement,
   shift,
   useDismiss,
   useFloating,
@@ -25,17 +26,24 @@ import { CssVariables } from "../game/components/CssVariables";
 export type TooltipProps = {
   triggerContent: ReactNode;
   tooltipContent?: ReactNode;
+  tooltipOffset?: number;
+  tooltipPlacement?: Placement;
 };
 
-export const Tooltip = ({ triggerContent, tooltipContent }: TooltipProps) => {
+export const Tooltip = ({
+  triggerContent,
+  tooltipContent,
+  tooltipOffset = 0,
+  tooltipPlacement = "bottom-end",
+}: TooltipProps) => {
   const [isOpen, setIsOpen] = useState(false);
 
   const { refs, floatingStyles, context } = useFloating({
     open: isOpen,
     onOpenChange: setIsOpen,
-    placement: "bottom-end",
+    placement: tooltipPlacement,
     whileElementsMounted: autoUpdate,
-    middleware: [offset(0), flip(), shift()],
+    middleware: [offset(tooltipOffset), flip(), shift()],
   });
 
   const { getReferenceProps, getFloatingProps } = useInteractions([

--- a/src/utils/react/useElementSize.ts
+++ b/src/utils/react/useElementSize.ts
@@ -1,29 +1,36 @@
-import { useEffect, useRef, useState } from "preact/hooks";
+import { useCallback, useEffect, useState } from "preact/hooks";
 
 export type ElementSize = {
   width: number | undefined;
   height: number | undefined;
 };
 
-export const useElementSize = <T extends Element>() => {
-  const ref = useRef<T>(null);
+export const useElementSize = <T extends Element>({
+  measureFirstChild = false,
+}: { measureFirstChild?: boolean } = {}) => {
+  const [element, setElement] = useState<null | T>(null);
   const [size, setSize] = useState<ElementSize>({
     width: undefined,
     height: undefined,
   });
 
+  const ref = useCallback((el: null | T) => {
+    setElement(el);
+  }, []);
+
   useEffect(() => {
-    const el = ref.current;
-    if (el === null) {
+    const target =
+      measureFirstChild ? (element?.firstElementChild ?? null) : element;
+    if (target === null) {
       return;
     }
     const ro = new ResizeObserver(([entry]) => {
       const { width, height } = entry.contentRect;
       setSize({ width, height });
     });
-    ro.observe(el);
+    ro.observe(target);
     return () => ro.disconnect();
-  }, []);
+  }, [element, measureFirstChild]);
 
   return { ref, ...size };
 };


### PR DESCRIPTION
- **feat: editor insert-room buttons to splice new rooms between existing ones**
- **refactor: extract map room interactivity into decorator pattern with insert-room buttons on map**
- **feat: subroom-aware state, vertical splice, connect-to-existing, unified 6-direction map buttons with tooltips**
- **resolve several minor issues**
- **remove buttons that are not surpassed by the map**
- **handle keyboard navigation on editor map**
