### PR TITLE
chore: migrate to pnpm 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,12 +178,5 @@
   "engines": {
     "node": ">=25.6.1"
   },
-  "packageManager": "pnpm@10.30.1",
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "@swc/core",
-      "esbuild",
-      "supabase"
-    ]
-  }
+  "packageManager": "pnpm@11.5.1"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  "@swc/core": true
+  esbuild: true
+  supabase: true


### PR DESCRIPTION
Migrates the project's package manager to pnpm 11.

## Changes
- Bumps `packageManager` to `pnpm@11.5.1`.
- Moves the build-script allowlist out of `package.json`'s `pnpm.onlyBuiltDependencies` into a new `pnpm-workspace.yaml` as `allowBuilds` (`@swc/core`, `esbuild`, `supabase`). pnpm 11 no longer reads the `pnpm` field from `package.json`, and `onlyBuiltDependencies` is replaced by `allowBuilds`.

## Notes
- Node 22+ requirement is already satisfied (`engines.node: ">=25.6.1"`, CI on Node 25).
- CI needs no changes — `pnpm/action-setup@v5` has no pinned version, so it reads the new `packageManager` field automatically.
- pnpm 11's new security defaults (`minimumReleaseAge: 1440`, `blockExoticSubdeps: true`) are left at their defaults; flag if the 1-day release-age delay ever blocks a CI install.

## Verification
- `pnpm install` and `pnpm install --frozen-lockfile` both run clean under pnpm 11.5.1; build scripts (`esbuild`, `supabase`) execute (no `ERR_PNPM_IGNORED_BUILDS`); lockfile unchanged (`lockfileVersion: '9.0'`).

Independent of the oxlint migration (#908) — separate branch off `main`.

https://claude.ai/code/session_01NUYw3zsMCeKVu63sH5VSnZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01NUYw3zsMCeKVu63sH5VSnZ)_