### PR TITLE
fix: recover from WebGL context loss by saving and remounting the game on a fresh canvas

### DIFF
--- a/e2e/contextLoss.spec.ts
+++ b/e2e/contextLoss.spec.ts
@@ -1,0 +1,76 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  getCurrentRoomId,
+  waitForGameState,
+} from "./testUtils/gameStateQueries";
+import { osSlowness } from "./testUtils/infrastructure";
+import {
+  formatProjectName,
+  forwardBrowserConsoleToNodeConsole,
+} from "./testUtils/logging";
+import { startCampaignViaMenu } from "./testUtils/menuNavigation";
+import { setupE2ePage } from "./testUtils/pageSetup";
+
+test.describe("recovery from WebGL context loss", () => {
+  test.setTimeout(60_000 * osSlowness);
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    forwardBrowserConsoleToNodeConsole(
+      page,
+      formatProjectName(testInfo.project.name),
+    );
+    await setupE2ePage(page);
+  });
+
+  test("game remounts on a fresh canvas and keeps rendering after the context is lost", async ({
+    page,
+  }, testInfo) => {
+    // WEBGL_lose_context behaviour is browser-specific; we verify on chromium:
+    test.skip(
+      !testInfo.project.name.includes("chromium"),
+      "context-loss reproduction is only exercised on chromium",
+    );
+
+    await startCampaignViaMenu(page, testInfo.project.name, "originalGame");
+    await waitForGameState(page);
+
+    const roomBeforeLoss = await getCurrentRoomId(page);
+    const generationBeforeLoss = await page.evaluate(
+      () => window._e2e_store!.getState().glContext.generation,
+    );
+
+    // force a context loss the way a player would: via the cheats panel button:
+    const cheatsOpenButton = page.locator(
+      '[data-test-id="cheats-open-button"]',
+    );
+    await cheatsOpenButton.click();
+    await page
+      .locator('[data-test-id="cheats-menu"]')
+      .waitFor({ state: "visible" });
+    await page.click('[data-test-id="cheats-lose-gl-context"]');
+
+    // the loss bumps the generation, which remounts the game area; wait for the
+    // new game api to come up on the fresh canvas:
+    await page.waitForFunction(
+      (previousGeneration) =>
+        window._e2e_store!.getState().glContext.generation > previousGeneration,
+      generationBeforeLoss,
+    );
+    await waitForGameState(page);
+
+    expect(
+      await page.evaluate(
+        () => window._e2e_store!.getState().glContext.generation,
+      ),
+    ).toBe(generationBeforeLoss + 1);
+    // the game saved before remounting, so the player resumes the same room:
+    expect(await getCurrentRoomId(page)).toBe(roomBeforeLoss);
+
+    // give the rebuilt scene a moment to render before capturing:
+    await page.waitForTimeout(1000 * osSlowness);
+    await page.screenshot({
+      path: testInfo.outputPath("game-after-context-loss.png"),
+    });
+  });
+});

--- a/src/game/GameApi.tsx
+++ b/src/game/GameApi.tsx
@@ -18,4 +18,9 @@ export type GameApi<RoomId extends string = string> = {
   gameState: GameState<RoomId>;
   stop: () => void;
   reincarnateFrom: (gameState: SavedGame<RoomId>) => void;
+  /**
+   * Force a WebGL context loss, for exercising the context-loss recovery path
+   * (the game saves and remounts on a fresh canvas). Used by the cheats panel.
+   */
+  loseGlContext: () => void;
 };

--- a/src/game/components/App.tsx
+++ b/src/game/components/App.tsx
@@ -6,7 +6,9 @@ import { Route, Switch } from "wouter";
 import { GamePage } from "../../pages/gamePage/GamePage.tsx";
 import { importLutPage } from "../../pages/LutPage.import.ts";
 import { importSpritesPage } from "../../pages/spritesPage/SpritesPage.import.ts";
+import { useAppSelector } from "../../store/hooks.ts";
 import { useSpritesOption } from "../../store/slices/gameMenus/gameMenusSelectors.ts";
+import { selectGlContextGeneration } from "../../store/slices/glContext/glContextSlice.ts";
 import { store } from "../../store/store.ts";
 import { SpinnerHead } from "../../ui/Spinner.tsx";
 import { handleGameBoot } from "../handleGameBoot.ts";
@@ -29,13 +31,18 @@ const AppInner = () => {
     document.body.classList.toggle("colourised", !spritesOption.uncolourised);
   }, [spritesOption]);
 
+  // remount the whole game page when the WebGL context is lost: every
+  // gpu-resident resource died with the old context, so the cleanest recovery
+  // is to rebuild from a fresh canvas rather than patch the lost textures
+  const glContextGeneration = useAppSelector(selectGlContextGeneration);
+
   return (
     // css variables needs the store so has to be in AppInner, not App
     <Switch>
       <Route path="/">
         <CssVariables>
           <InputStateProvider ticker={pixiInputTicker}>
-            <GamePage />
+            <GamePage key={glContextGeneration} />
           </InputStateProvider>
         </CssVariables>
       </Route>

--- a/src/game/components/cheats/Cheats.tsx
+++ b/src/game/components/cheats/Cheats.tsx
@@ -770,6 +770,19 @@ export const Cheats = <RoomId extends string>(_emptyProps: EmptyObject) => {
                 lives--
               </Button>
             </div>
+            <Heading>webgl context:</Heading>
+            <div className="flex flex-row items-center flex-wrap">
+              <Button
+                data-test-id="cheats-lose-gl-context"
+                className="flex-grow h-3"
+                onClick={(e) => {
+                  gameApi.loseGlContext();
+                  (e?.currentTarget as HTMLElement | undefined)?.blur();
+                }}
+              >
+                lose gl context
+              </Button>
+            </div>
             <Heading>write to console:</Heading>
             <div className="flex flex-row items-center flex-wrap">
               <Button

--- a/src/game/gameMain.ts
+++ b/src/game/gameMain.ts
@@ -8,6 +8,7 @@ import {
   gameRestoreFromSave,
   roomExplored,
 } from "../store/slices/gameInPlay/gameInPlaySlice";
+import { glContextLost } from "../store/slices/glContext/glContextSlice";
 import { selectSaveForCampaign } from "../store/slices/savedGames/savedGamesSlice";
 import { store } from "../store/store";
 import { trackTextures } from "../textureInspector/trackTextures";
@@ -19,6 +20,7 @@ import { selectCurrentPlayableItem } from "./gameState/gameStateSelectors/select
 import { loadGameState } from "./gameState/loadGameState";
 import { changeCharacterRoom } from "./gameState/mutators/changeCharacterRoom";
 import { type SavedGame } from "./gameState/saving/SavedGameState";
+import { saveGameThunk } from "./gameState/saving/saveGameThunk";
 import { type InputStateTrackerInterface } from "./input/InputStateTracker";
 import { MainLoop } from "./mainLoop/MainLoop";
 
@@ -85,17 +87,8 @@ export const gameMain = async <RoomId extends string>(
 
   if (import.meta.env.DEV) {
     trackTextures(app);
-
-    // a lost context blanks every runtime-baked RenderTexture (they have no
-    // cpu-side resource to restore from). The MainLoop rebuilds them when the
-    // context is restored - log here so occurrences are visible in dev:
-    app.canvas.addEventListener("webglcontextlost", () => {
-      console.error("WebGL context lost");
-    });
-    app.canvas.addEventListener("webglcontextrestored", () => {
-      console.error("WebGL context restored");
-    });
   }
+
   stopAppAutoRendering(app);
 
   // only put on window after initialised and maxFPS set - this ensures it can also be
@@ -129,6 +122,23 @@ export const gameMain = async <RoomId extends string>(
       store.dispatch(roomExplored(gameState.characterRooms.heels.id));
     }
   }
+
+  // a lost context blanks every runtime-baked RenderTexture (they have no
+  // cpu-side resource to restore from), and the same canvas may never get its
+  // context back. Rather than rebuild in place, save the game so no progress is
+  // lost, then dispatch glContextLost so the React layer remounts the whole
+  // game area on a fresh canvas, reconstructing every texture from scratch.
+  // once: true since this app instance is about to be torn down and replaced:
+  const onContextLost = () => {
+    if (import.meta.env.DEV) {
+      console.error("WebGL context lost");
+    }
+    store.dispatch(saveGameThunk(gameState));
+    store.dispatch(glContextLost());
+  };
+  app.canvas.addEventListener("webglcontextlost", onContextLost, {
+    once: true,
+  });
 
   const loop = new MainLoop(app, gameState, spritesheetVariants).start();
 
@@ -175,8 +185,12 @@ export const gameMain = async <RoomId extends string>(
         writeInto: gameState,
       });
     },
+    loseGlContext() {
+      app.renderer.gl.getExtension("WEBGL_lose_context")?.loseContext();
+    },
     stop() {
       console.warn("tearing down game");
+      app.canvas.removeEventListener("webglcontextlost", onContextLost);
       app.canvas.parentNode?.removeChild(app.canvas);
       loop.stop();
       app.destroy();

--- a/src/game/mainLoop/MainLoop.ts
+++ b/src/game/mainLoop/MainLoop.ts
@@ -80,23 +80,6 @@ export class MainLoop<RoomId extends string> {
   #gameState: GameState<RoomId>;
   #spritesheetVariants: SpritesheetVariants;
 
-  /**
-   * set when the WebGL context has been restored after being lost. Every
-   * render texture's contents died with the old context, so the next tick
-   * must rebuild everything baked at runtime: the spritesheets, the room
-   * renderer, and the hud (including its baked text)
-   */
-  #contextRestored = false;
-
-  /**
-   * called by pixi's contextChange runner. The initial context creation
-   * happens during app.init(), before this MainLoop is constructed, so any
-   * call here is a restore after a lost context.
-   */
-  contextChange() {
-    this.#contextRestored = true;
-  }
-
   constructor(
     app: Application,
     gameState: GameState<RoomId>,
@@ -105,7 +88,6 @@ export class MainLoop<RoomId extends string> {
     this.#app = app;
     this.#gameState = gameState;
     this.#spritesheetVariants = spritesheetVariants;
-    app.renderer.runners.contextChange.add(this);
     try {
       const storeState = store.getState();
 
@@ -234,16 +216,6 @@ export class MainLoop<RoomId extends string> {
       // the game is over - there's no need to do any more in this loop, and the loop should
       // soon terminate:
       return;
-    }
-
-    if (this.#contextRestored) {
-      this.#contextRestored = false;
-      // destroy before invalidating the sheets the renderers reference:
-      this.#hudRenderer?.destroy();
-      this.#hudRenderer = undefined;
-      this.#roomRenderer?.destroy();
-      this.#roomRenderer = undefined;
-      this.#spritesheetVariants.invalidate();
     }
 
     const roomChanged = this.#roomRenderer?.renderContext.room !== tickEndRoom;
@@ -477,7 +449,6 @@ export class MainLoop<RoomId extends string> {
     this.#worldSound.disconnect();
     this.#roomRenderer?.destroy();
     this.#hudRenderer?.destroy();
-    this.#app.renderer.runners.contextChange.remove(this);
     this.#app.ticker.remove(this.#tickAndCatch);
   }
 }

--- a/src/pages/gamePage/GamePage.tsx
+++ b/src/pages/gamePage/GamePage.tsx
@@ -172,7 +172,7 @@ export const GamePage = () => {
           <AddAnalyticsToStore />
           <ConnectInputToStore />
 
-          {/* 
+          {/*
           dialogs are html and therefore rotated using css, as opposed
           to the game engine which can be rotated using opengl transforms
           */}

--- a/src/sprites/spritesheet/variants/SpritesheetVariants.ts
+++ b/src/sprites/spritesheet/variants/SpritesheetVariants.ts
@@ -325,21 +325,6 @@ export class SpritesheetVariants {
     return spriteSheet;
   }
 
-  /**
-   * destroys all baked sheets so that the next rebuild() reconstructs them
-   * from the loaded base image. Needed after a WebGL context restore: the
-   * sheets are render textures, whose contents do not survive a lost context
-   * (unlike image-backed textures, they have no cpu-side resource to restore
-   * from)
-   */
-  invalidate(): void {
-    destroySpritesheet(this.#originalSpritesheet);
-    this.#originalSpritesheet = undefined;
-    this.#destroyColourisedVariants();
-    destroySpritesheet(this.#uncolourisedSpritesheet);
-    this.#uncolourisedSpritesheet = undefined;
-  }
-
   #destroyColourisedVariants() {
     destroySpritesheet(this.#forCurrentRoomSpritesheet);
     destroySpritesheet(this.#deactivatedSpritesheet);

--- a/src/store/slices/glContext/glContextSlice.ts
+++ b/src/store/slices/glContext/glContextSlice.ts
@@ -1,0 +1,45 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+import { clearAllData } from "../clearAllData";
+
+export type GlContextState = {
+  /**
+   * incremented each time the WebGL context is lost. Used as a React `key`
+   * on the game render area so a context loss tears down and remounts the
+   * whole pixi Application (and its spritesheet variants) on a fresh canvas.
+   * Every runtime-baked RenderTexture is then regenerated from scratch during
+   * construction - something a same-canvas restore cannot reliably do, since
+   * those textures have no cpu-side resource to restore from.
+   */
+  generation: number;
+};
+
+const initialState: GlContextState = {
+  generation: 0,
+};
+
+/**
+ * Tracks WebGL context losses. A loss invalidates every gpu-resident
+ * resource, so rather than rebuild in place we bump a generation counter and
+ * let the React layer remount the game area keyed on it.
+ */
+export const glContextSlice = createSlice({
+  name: "glContext",
+  initialState,
+  reducers: {
+    glContextLost(state) {
+      state.generation++;
+    },
+  },
+  extraReducers(builder) {
+    builder.addCase(clearAllData, () => initialState);
+  },
+  selectors: {
+    selectGlContextGeneration(state: GlContextState) {
+      return state.generation;
+    },
+  },
+});
+
+export const { glContextLost } = glContextSlice.actions;
+export const { selectGlContextGeneration } = glContextSlice.selectors;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -52,6 +52,7 @@ import { registerGameMenusListeners } from "./slices/gameMenus/gameMenusListener
 import { gameMenusSlice } from "./slices/gameMenus/gameMenusSlice";
 import { playMenuSoundsOnStoreChanges } from "./slices/gameMenus/playMenuSoundsOnStoreChanges";
 import { githubApiSlice } from "./slices/githubApiSlice";
+import { glContextSlice } from "./slices/glContext/glContextSlice";
 import { registerSavedGamesListeners } from "./slices/savedGames/savedGamesListeners";
 import { savedGamesSlice } from "./slices/savedGames/savedGamesSlice";
 import { spritesheetOverrideSlice } from "./slices/spritesheetOverrideSlice";
@@ -73,6 +74,7 @@ const appReducer = combineSlices({
   [assetsLoadingSlice.reducerPath]: assetsLoadingSlice.reducer,
   [spritesheetOverrideSlice.reducerPath]: spritesheetOverridePersistedReducer,
   [debugSlice.reducerPath]: debugSlice.reducer,
+  [glContextSlice.reducerPath]: glContextSlice.reducer,
   ...(import.meta.env.VITE_APP === "editor" ?
     {
       levelEditor: levelEditorPersistedReducer,


### PR DESCRIPTION
## Problem

On a WebGL context loss the previous in-place recovery (rebuild baked spritesheets/room/HUD on `contextChange`) wasn't reliably working — the earliest runtime-baked render textures stayed blank, and even the room and HUD failed to come back. The player was left having to reload the whole app.

## Approach

Rather than surgically re-bake individual render textures into a possibly-dead context, react to a loss by remounting the entire game area on a **fresh canvas**, so every gpu-resident resource is reconstructed from scratch during normal construction. This is deliberately a slightly heavy reaction, but context loss is rare and destructive, and anything short of a full app reload is an improvement.

- New `glContextSlice` holds a single integer `generation`, bumped by a `glContextLost` action.
- On `webglcontextlost`, `gameMain` first dispatches `saveGameThunk` (so no progress is lost), then `glContextLost`.
- `App.tsx` keys `<GamePage>` on the generation — a bump remounts the whole game page, tearing down the old pixi `Application` and creating a new one with a fresh context, and recreating the `SpritesheetVariants`.
- On remount the just-saved game is restored, so the player resumes in the same room.

## Cheats button

Added a **"lose gl context"** button to the cheats panel (`gameApi.loseGlContext()` → `WEBGL_lose_context.loseContext()`) to make the recovery path easy to exercise by hand.

## Verification

`e2e/contextLoss.spec.ts` (chromium) starts the original campaign, triggers a loss via the cheats button, and asserts the generation increments by exactly 1 and the player resumes the same room. A manual demo run also confirmed via console that the browser fired a real `webglcontextlost` event on the canvas, and screenshots confirmed the room, player and HUD all re-rendered after the loss.

`pnpm check` passes (builds, typechecks, lint, format, 9304 unit tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzkgNEjVK9Y1UEExijrY61)_