### PR TITLE
fix: bake HUD text from a detached container so render-group state can't blank it

### DIFF
--- a/src/game/render/text/TextContainer.ts
+++ b/src/game/render/text/TextContainer.ts
@@ -104,8 +104,13 @@ export class TextContainer extends Container {
     );
     this.addChild(this.#renderCacheSprite);
 
+    // deliberately NOT added to this container / the scene graph: it exists
+    // only to be render-to-textured into #renderCacheSprite. Keeping it detached
+    // means the bake renders a container with no parentRenderGroup - rendering a
+    // container that is already part of a render group (the HUD is one) to a
+    // texture corrupts the render-group state and bakes blank/broken text that
+    // never recovers. The visible output is the separate #renderCacheSprite:
     this.#renderToCacheContainer = new Container<Container<Sprite>>();
-    this.addChild(this.#renderToCacheContainer);
 
     this.#characterSpriteContainer = new Container<Sprite>();
     this.#characterSpriteContainer.scale = {
@@ -262,6 +267,10 @@ export class TextContainer extends Container {
     clearTimeout(this.#flashTimeout);
     // always destroy the cached texture/source when the text container is destroyed:
     this.#renderCacheSprite.destroy({ texture: true, textureSource: true });
+    // #renderToCacheContainer is detached from the scene graph, so super.destroy
+    // won't reach it - destroy it explicitly. Its sprites' textures belong to the
+    // shared spritesheet, so are not destroyed here:
+    this.#renderToCacheContainer.destroy({ children: true });
     super.destroy(options);
   }
 


### PR DESCRIPTION
## Problem

HUD numbers (and other `TextContainer` text) intermittently render blank/broken and, once broken, **never recover** — even when the value changes and the text re-bakes (e.g. losing a life updates the number but it stays broken). That rules out the bake timing or the change-detection guard, and points at something captured/established when the container is first rendered, not when it re-renders.

## Root cause

`TextContainer` bakes its glyphs into a cached `RenderTexture` by calling `pixiRenderer.render({ container: #renderToCacheContainer, target })`. But `#renderToCacheContainer` was permanently `addChild`'d to the `TextContainer`, which lives inside the HUD container — and the HUD is a **render group** (`new Container({ isRenderGroup: true })`). So the bake render-to-textures a container that is *already part of a live render group*.

In Pixi v8 that entangles the container's render-group GPU/instruction state between the off-screen bake and the on-screen group; once it tips into a bad state it stays bad, so every subsequent re-bake reproduces the broken texture. This is different from the bakes that work (the spritesheet bake, and `renderContainerToTexture`'s intended use), which render a freshly-created, **detached** display object.

## Fix

Don't put `#renderToCacheContainer` in the scene graph. It exists solely to be render-to-textured into the visible `#renderCacheSprite`, so keeping it detached makes the bake render a parent-less container with no `parentRenderGroup` — matching the working spritesheet-bake pattern. (It's now destroyed explicitly, since `super.destroy` no longer reaches it.)

## Verification

- `pnpm check` green (builds, typechecks, lint, format, 9304 unit tests).
- Confirmed in a chromium run that HUD lives/count digits still render correctly (no regression). The intermittent failure itself needs real-device testing to confirm fixed.

Opened off `main` as a standalone change (independent of the context-loss work in #948, which is left open for further testing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzkgNEjVK9Y1UEExijrY61)_