### PR TITLE
true-site-size: compare every PR against both main and production

### DIFF
--- a/.github/workflows/true-site-size.yml
+++ b/.github/workflows/true-site-size.yml
@@ -24,10 +24,10 @@ jobs:
             journey: |
               [
                 { "goto": "/?track=0" },
-                { "row": "main menu", "mark": "menu-ready" },
+                { "row": "to menu", "mark": "menu-ready" },
                 { "click": "[data-menuitem_id=\"playGame\"]" },
                 { "click": "[data-menuitem_id=\"originalGame\"]" },
-                { "row": "play game", "mark": "first-gameplay" }
+                { "row": "to game", "mark": "first-gameplay" }
               ]
           - target: editor
             build-command: pnpm build:editor

--- a/.github/workflows/true-site-size.yml
+++ b/.github/workflows/true-site-size.yml
@@ -85,8 +85,7 @@ jobs:
           compression-level: 11
           ignore-url-patterns: '["supabase\\.co"]'
           minimum-change-threshold: 50
-          # For release-please PRs, compare against the production branch
-          # (= previous release) to show the cumulative change across the
-          # whole release rather than the empty diff of a version bump.
-          base-ref: ${{ startsWith(github.head_ref, 'release-please--') && 'production' || '' }}
+          # compare every PR against both main (its merge target) and
+          # production (= the last release), each as its own column
+          base-refs: '["main", "production"]'
           journey: ${{ matrix.journey }}


### PR DESCRIPTION
Switches the size report from a release-please-only conditional `base-ref` to two explicit `base-refs`, using the new multi-ref support in [true-site-size](https://github.com/jimhigson/true-site-size). Every PR now gets a column for **main** (its merge target) and **production** (the last release), each linked to the exact commit and annotated with `git describe`.

Verified locally via `act` against the game build — both columns render, with `main` shown as `v24.0.0-10-g950e94e7` and `production` as `v24.0.0`, plus per-file breakdowns vs each ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)