### PR TITLE
fix: PWA fills the whole screen on iOS by driving upscale from a css-filled element

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" className="max-h-full">
+<html lang="en" class="max-h-full">
   <head>
     <title>Head over Heels Blockstack.ing remake</title>
     <meta charset="UTF-8" />
@@ -18,8 +18,8 @@
     />
   </head>
 
-  <body className="max-h-full">
-    <div id="root" className="max-h-full"></div>
+  <body class="max-h-full">
+    <div id="root" class="max-h-full"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/editor/index.html
+++ b/src/editor/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" className="max-h-full">
+<html lang="en" class="max-h-full">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.png" />
@@ -19,8 +19,8 @@
     ></script>
   </head>
 
-  <body className="max-h-full">
-    <div id="root" className="max-h-full"></div>
+  <body class="max-h-full">
+    <div id="root" class="max-h-full"></div>
     <script type="module" src="main.tsx"></script>
   </body>
 </html>

--- a/src/index.css
+++ b/src/index.css
@@ -4,6 +4,15 @@
 @tailwind utilities;
 
 @layer base {
+  html,
+  body,
+  #root {
+    /* establish a height chain so the app can fill the viewport. Without this
+       the body collapses to zero height, which on iOS standalone web apps
+       leaves the app sized to a stale/partial viewport rather than the screen */
+    height: 100%;
+  }
+
   body {
     /* TODO: revert and use only while loading */
     background-color: black;

--- a/src/pages/gamePage/GamePage.tsx
+++ b/src/pages/gamePage/GamePage.tsx
@@ -23,6 +23,8 @@ import {
   selectCanvasSize,
   selectRot90,
 } from "../../store/slices/upscale/upscaleSlice.ts";
+import { useUpdateUpscaleOnDisplaySettingsChange } from "../../store/slices/upscale/useUpdateUpscaleOnDisplaySettingsChange.ts";
+import { useUpdateUpscaleWhenElementResizes } from "../../store/slices/upscale/useUpdateUpscaleWhenElementResizes.ts";
 import { store } from "../../store/store.ts";
 import { ConnectInputToStore } from "../../store/storeFlow/ConnectInputToStore.tsx";
 import { DispatchingErrorBoundary } from "../../utils/react/DispatchingErrorBoundary.tsx";
@@ -119,6 +121,12 @@ const useCreateGameApi = (): GameApi<string> | undefined => {
  */
 export const GamePage = () => {
   const [renderArea, setRenderArea] = useState<HTMLDivElement | null>(null);
+  // a CSS-filled element whose size drives the upscale. Measuring this via a
+  // ResizeObserver (rather than reading window.innerWidth/innerHeight on the
+  // window 'resize' event) tracks the real available area more reliably on
+  // iOS, where the standalone web-app viewport settles late after rotation.
+  const [renderSizingArea, setRenderSizingArea] =
+    useState<HTMLDivElement | null>(null);
 
   const cheatsOn = useCheatsOn();
   const gameApi = useCreateGameApi();
@@ -128,6 +136,11 @@ export const GamePage = () => {
   const canvasInlineStyle = useCanvasInlineStyle();
 
   usePageAsAnApp();
+  useUpdateUpscaleWhenElementResizes(undefined, renderSizingArea ?? undefined);
+  useUpdateUpscaleOnDisplaySettingsChange(
+    undefined,
+    renderSizingArea ?? undefined,
+  );
   useEffect(() => {
     if (renderArea === null || gameApi === undefined) {
       return;
@@ -148,16 +161,22 @@ export const GamePage = () => {
   return (
     <>
       {/* 👇👇 where the magic happens - the element the game plays in! 👇👇 */}
-      <div
-        // without tabIndex here, Chrome doesn't allow tab key to be used to open the map
-        // (or anything else) because it moves focus to the address bar
-        tabIndex={0}
-        // without fixed top-0, sometimes on MacOs Safari, after going to the map and back
-        // the game's area is rendered scrolled up the screen
-        className="fixed top-0"
-        style={canvasInlineStyle}
-        ref={setRenderArea}
-      />
+      {/* the sizing area fills the real screen via css (not js-measured pixels),
+          so even if the upscale is computed from a momentarily-wrong viewport
+          the black backdrop still covers the whole screen. Its measured size
+          drives the upscale. */}
+      <div ref={setRenderSizingArea} className="fixed inset-0">
+        <div
+          // without tabIndex here, Chrome doesn't allow tab key to be used to open the map
+          // (or anything else) because it moves focus to the address bar
+          tabIndex={0}
+          // without top-0/left-0, sometimes on MacOs Safari, after going to the map and back
+          // the game's area is rendered scrolled up the screen
+          className="absolute top-0 left-0"
+          style={canvasInlineStyle}
+          ref={setRenderArea}
+        />
+      </div>
       <GameApiProvider gameApi={gameApi}>
         <DispatchingErrorBoundary>
           <AddAnalyticsToStore />

--- a/src/store/storeFlow/ConnectInputToStore.tsx
+++ b/src/store/storeFlow/ConnectInputToStore.tsx
@@ -1,12 +1,8 @@
-import { useUpdateUpscaleOnDisplaySettingsChange } from "../slices/upscale/useUpdateUpscaleOnDisplaySettingsChange";
-import { useUpdateUpscaleWhenElementResizes } from "../slices/upscale/useUpdateUpscaleWhenElementResizes";
 import { useHoldOnWindowHidden } from "./useHoldOnWindowHidden";
 import { useSaveGameOnUnload } from "./useSaveGameOnUnload";
 import { useUniversalKeys } from "./useUniversalKeys";
 
 export const ConnectInputToStore = () => {
-  useUpdateUpscaleWhenElementResizes();
-  useUpdateUpscaleOnDisplaySettingsChange();
   useUniversalKeys();
   useHoldOnWindowHidden();
   useSaveGameOnUnload();


### PR DESCRIPTION
The full-screen sizing of the PWA was unreliable on iPhone — sometimes needing a couple of orientation changes before it sized correctly.

Root cause: the game's outer space was bolted to a JS pixel measurement. In-game, the upscale was computed from `window.innerWidth/innerHeight` read on the window `resize` event (the editor already avoids this — it measures a css-filled element via a `ResizeObserver`). On iOS the standalone web-app viewport settles late after rotation, so that measurement is stale, and because the render area is sized in hard pixels nothing stretches it back out — leaving the app in a box smaller than the screen until another rotation re-fires the measurement.

Two contributing layout faults found while investigating:
- the html shell used `className` (ignored by the browser on static html) instead of `class`, so the intended `max-h-full` was dead
- the game css had no `height: 100%` chain (the editor css has one), so `<body>` collapsed to `0px` height

Changes:
- `src/index.css`: add `html, body, #root { height: 100% }` height chain (matching the editor)
- `index.html` / `src/editor/index.html`: `className` → `class`
- `GamePage.tsx`: render the game inside a css-filled `fixed inset-0` sizing element, and drive the upscale from its measured size via the existing `ResizeObserver` path (the editor's pattern) instead of `window.innerWidth/innerHeight`. The backdrop now covers the whole screen even if the upscale is momentarily computed from a wrong viewport.
- `ConnectInputToStore.tsx`: drop the window-based upscale hooks (moved to `GamePage`, where the sizing element exists)

Verified in chromium (iPhone emulation, `?device=mobile`) that web rendering is unchanged: body height now resolves to the viewport (was `0px`), the sizing element fills, and the upscale recomputes correctly across a simulated rotation — portrait and landscape both fill with no black bars or distortion.

Note: chromium can't reproduce the iOS-specific standalone-viewport behaviour, so the fix needs verifying on a real iPhone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfndxfCcMstVqPXx5MARWu)_