### PR TITLE
fix: cheats room shortcuts crash campaigns without those rooms

### DIFF
--- a/e2e/persistOnReload.spec.ts
+++ b/e2e/persistOnReload.spec.ts
@@ -5,6 +5,7 @@ import {
   sequelCampaignLocator,
 } from "../src/gameInfo";
 import {
+  changeToAnotherRoom,
   clickCheat,
   dismissHoldAfterReload,
   dispatchKeyPress,
@@ -70,7 +71,9 @@ test.describe("persistence across reload", () => {
     const otherCharacter = await getCurrentCharacter(page);
     expect(otherCharacter).not.toBe(startCharacter);
 
-    await clickCheat(page, "cheats-goto-room-finalroom");
+    // the cheats' room shortcuts name original-campaign rooms, which the sequel
+    // does not have - change to a room this campaign really contains:
+    await changeToAnotherRoom(page);
     await page.waitForTimeout(1_000 * osSlowness);
     const roomBeforeReload = await getCurrentRoomId(page);
 

--- a/e2e/scrollAndKeyRebind.spec.ts
+++ b/e2e/scrollAndKeyRebind.spec.ts
@@ -1,6 +1,9 @@
 import { expect, type Page } from "@playwright/test";
 
-import { dispatchKeyPress } from "./testUtils/gameInteractions";
+import {
+  dispatchKeyPress,
+  waitForAssigningInput,
+} from "./testUtils/gameInteractions";
 import { osSlowness } from "./testUtils/infrastructure";
 import { formatProjectName } from "./testUtils/logging";
 import {
@@ -120,6 +123,7 @@ test.describe("key rebinding and scroll pickup", () => {
 
     await test.step("Rebind down to '6' via the assignment UI", async () => {
       await navigateToSubmenu(page, "down", formattedName);
+      await waitForAssigningInput(page);
       await dispatchKeyPress(page, "6", "Digit6");
       await page.waitForTimeout(200 * osSlowness);
       await dispatchKeyPress(page, "Escape", "Escape");

--- a/e2e/testUtils/gameInteractions.ts
+++ b/e2e/testUtils/gameInteractions.ts
@@ -185,3 +185,49 @@ export const dismissHoldAfterReload = async (page: Page) => {
     .locator('[data-dialog-id="hold"]')
     .waitFor({ state: "detached", timeout: 5_000 * osSlowness });
 };
+
+/**
+ * change to any room of the loaded campaign other than the one the current
+ * character is in, and return its id. Unlike the cheats panel's room
+ * shortcuts, which name rooms of the original campaign, this works whatever
+ * campaign is loaded
+ */
+export const changeToAnotherRoom = async (page: Page): Promise<string> =>
+  page.evaluate(() => {
+    const gameApi = window._e2e_gamePageGameAi;
+    if (gameApi === undefined) {
+      throw new Error("no game api - the game has not finished loading");
+    }
+    const currentRoomId = gameApi.currentRoom?.id;
+    const otherRoomId = Object.keys(gameApi.campaign.rooms).find(
+      (roomId) => roomId !== currentRoomId,
+    );
+    if (otherRoomId === undefined) {
+      throw new Error("campaign has no room other than the current one");
+    }
+    gameApi.changeRoom(otherRoomId);
+    return otherRoomId;
+  });
+
+/**
+ * wait until the control options are actually listening for the key to assign.
+ *
+ * Entering assigning mode is two steps: the store records it synchronously,
+ * then a render later an effect subscribes to the ticker. Only a key pressed
+ * after that subscription counts - one already down when it happens reads as
+ * held rather than as a fresh press, and is never assigned. Preact flushes
+ * effects on a task after a frame, so waiting one frame is not enough to be
+ * sure the second step has happened.
+ */
+export const waitForAssigningInput = async (page: Page): Promise<void> => {
+  await page.waitForFunction(
+    () =>
+      window._e2e_store?.getState().userSettings.assigningInput !== undefined,
+  );
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        requestAnimationFrame(() => setTimeout(() => resolve(), 0));
+      }),
+  );
+};

--- a/src/game/components/cheats/Cheats.tsx
+++ b/src/game/components/cheats/Cheats.tsx
@@ -223,11 +223,18 @@ export type GoToRoomButtonProps<RoomId extends string> = {
   readonly roomId: RoomId;
 };
 
+/**
+ * shortcuts to some named rooms, if they exist in the current campaign
+ */
 export const GoToRoomButton = <RoomId extends string>({
   gameApi,
   roomId,
   children,
 }: PropsWithChildren<GoToRoomButtonProps<RoomId>>) => {
+  if (gameApi.campaign.rooms[roomId] === undefined) {
+    return null;
+  }
+
   return (
     <Button
       data-test-id={`cheats-goto-room-${roomId}`}


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>